### PR TITLE
Remove Slot position overrides from SampleScene

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -428,18 +428,6 @@ PrefabInstance:
       value: Slot
       objectReference: {fileID: 0}
     - target: {fileID: 5641854483612295093, guid: a5364a716ff173a4f8424305f316e846, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5641854483612295093, guid: a5364a716ff173a4f8424305f316e846, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5641854483612295093, guid: a5364a716ff173a4f8424305f316e846, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5641854483612295093, guid: a5364a716ff173a4f8424305f316e846, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}


### PR DESCRIPTION
## Summary
- remove local position overrides for the Slot prefab instance in SampleScene so the prefab's transform settings propagate

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68cec1bb8f3883228311ffc041b8d4c2