### PR TITLE
Add Hand Area prefab with ten Card instances

### DIFF
--- a/Assets/Prefabs/Hand Area.prefab
+++ b/Assets/Prefabs/Hand Area.prefab
@@ -1,0 +1,877 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7275409715227946938
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5960789342781726645}
+  m_Layer: 5
+  m_Name: Hand Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5960789342781726645
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7275409715227946938}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2001000000000000000}
+  - {fileID: 2001000000000000001}
+  - {fileID: 2001000000000000002}
+  - {fileID: 2001000000000000003}
+  - {fileID: 2001000000000000004}
+  - {fileID: 2001000000000000005}
+  - {fileID: 2001000000000000006}
+  - {fileID: 2001000000000000007}
+  - {fileID: 2001000000000000008}
+  - {fileID: 2001000000000000009}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 80}
+  m_SizeDelta: {x: 1100, y: 220}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &1001000000000000000
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5960789342781726645}
+    m_Modifications:
+    - target: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_Name
+      value: Card (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -495
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+--- !u!1 &3001000000000000000 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000000}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2001000000000000000 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000000}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1001000000000000001
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5960789342781726645}
+    m_Modifications:
+    - target: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_Name
+      value: Card (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -385
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+--- !u!1 &3001000000000000001 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000001}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2001000000000000001 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000001}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1001000000000000002
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5960789342781726645}
+    m_Modifications:
+    - target: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_Name
+      value: Card (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -275
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+--- !u!1 &3001000000000000002 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000002}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2001000000000000002 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000002}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1001000000000000003
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5960789342781726645}
+    m_Modifications:
+    - target: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_Name
+      value: Card (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -165
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+--- !u!1 &3001000000000000003 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000003}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2001000000000000003 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000003}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1001000000000000004
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5960789342781726645}
+    m_Modifications:
+    - target: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_Name
+      value: Card (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -55
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+--- !u!1 &3001000000000000004 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000004}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2001000000000000004 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000004}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1001000000000000005
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5960789342781726645}
+    m_Modifications:
+    - target: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_Name
+      value: Card (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 55
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+--- !u!1 &3001000000000000005 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000005}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2001000000000000005 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000005}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1001000000000000006
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5960789342781726645}
+    m_Modifications:
+    - target: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_Name
+      value: Card (7)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 165
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+--- !u!1 &3001000000000000006 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000006}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2001000000000000006 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000006}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1001000000000000007
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5960789342781726645}
+    m_Modifications:
+    - target: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_Name
+      value: Card (8)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 275
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+--- !u!1 &3001000000000000007 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000007}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2001000000000000007 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000007}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1001000000000000008
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5960789342781726645}
+    m_Modifications:
+    - target: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_Name
+      value: Card (9)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 385
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+--- !u!1 &3001000000000000008 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000008}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2001000000000000008 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000008}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1001000000000000009
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5960789342781726645}
+    m_Modifications:
+    - target: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_Name
+      value: Card (10)
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 495
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+--- !u!1 &3001000000000000009 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000009}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &2001000000000000009 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000009}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Hand Area.prefab.meta
+++ b/Assets/Prefabs/Hand Area.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a40dac4228624a7db956ad525dc56202
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add a new Hand Area prefab that hosts ten Card prefab instances spaced across the container

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cecd695d2c8322ba4f0511db5d1b93