### PR TITLE
Add hand area hover interaction

### DIFF
--- a/Assets/Prefabs/Hand Area.prefab
+++ b/Assets/Prefabs/Hand Area.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5960789342781726645}
+  - component: {fileID: 10750391591452872197}
   m_Layer: 5
   m_Name: Hand Area
   m_TagString: Untagged
@@ -45,6 +46,24 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 80}
   m_SizeDelta: {x: 1100, y: 220}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &10750391591452872197
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7275409715227946938}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d071dffd52ad401a8d3ccfd8b79aa983, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  defaultSpacing: 10
+  expandedSpacing: 40
+  hoverYOffset: 40
+  positionSmoothTime: 0.1
+  hoverCheckInterval: 0.03
+  uiCamera: {fileID: 0}
 --- !u!1001 &1001000000000000000
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/HandAreaHover.cs
+++ b/Assets/Scripts/HandAreaHover.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+[RequireComponent(typeof(RectTransform))]
+public class HandAreaHover : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerMoveHandler
+{
+    [Header("Layout")]
+    public float defaultSpacing = 10f;
+    public float expandedSpacing = 40f;
+    public float hoverYOffset = 40f;
+
+    [Header("Animation")]
+    public float positionSmoothTime = 0.1f;
+    public float hoverCheckInterval = 0.03f;
+    public Camera uiCamera;
+
+    private readonly List<RectTransform> _cardRects = new List<RectTransform>();
+    private readonly List<Vector2> _velocity = new List<Vector2>();
+
+    private bool _isHovered;
+    private int _hoveredIndex = -1;
+    private float _nextHoverCheck;
+
+    public void Awake()
+    {
+        CacheCards();
+    }
+
+    public void OnEnable()
+    {
+        CacheCards();
+    }
+
+    public void OnPointerEnter(PointerEventData eventData)
+    {
+        _isHovered = true;
+        _nextHoverCheck = 0f;
+    }
+
+    public void OnPointerExit(PointerEventData eventData)
+    {
+        _isHovered = false;
+        _hoveredIndex = -1;
+    }
+
+    public void OnPointerMove(PointerEventData eventData)
+    {
+        UpdateHoveredCard(eventData.position);
+    }
+
+    private void Update()
+    {
+        if (_isHovered)
+        {
+            if (_nextHoverCheck <= 0f)
+            {
+                UpdateHoveredCard(Input.mousePosition);
+                _nextHoverCheck = hoverCheckInterval;
+            }
+            else
+            {
+                _nextHoverCheck -= Time.unscaledDeltaTime;
+            }
+        }
+
+        UpdateCardPositions();
+    }
+
+    private void CacheCards()
+    {
+        _cardRects.Clear();
+        _velocity.Clear();
+
+        for (int i = 0; i < transform.childCount; i++)
+        {
+            var child = transform.GetChild(i) as RectTransform;
+            if (child == null || !child.gameObject.activeInHierarchy)
+            {
+                continue;
+            }
+
+            _cardRects.Add(child);
+            _velocity.Add(Vector2.zero);
+        }
+    }
+
+    private void UpdateHoveredCard(Vector2 pointerPosition)
+    {
+        _hoveredIndex = -1;
+
+        for (int i = 0; i < _cardRects.Count; i++)
+        {
+            if (RectTransformUtility.RectangleContainsScreenPoint(_cardRects[i], pointerPosition, uiCamera))
+            {
+                _hoveredIndex = i;
+                break;
+            }
+        }
+    }
+
+    private void UpdateCardPositions()
+    {
+        if (_cardRects.Count == 0)
+        {
+            return;
+        }
+
+        float spacing = _isHovered ? expandedSpacing : defaultSpacing;
+        float totalWidth = spacing * (_cardRects.Count - 1);
+        float startX = -totalWidth * 0.5f;
+
+        for (int i = 0; i < _cardRects.Count; i++)
+        {
+            float targetX = startX + spacing * i;
+            float targetY = 0f;
+
+            if (_isHovered && i == _hoveredIndex)
+            {
+                targetY += hoverYOffset;
+            }
+
+            RectTransform card = _cardRects[i];
+            Vector2 target = new Vector2(targetX, targetY);
+            Vector2 current = card.anchoredPosition;
+            Vector2 velocity = _velocity[i];
+
+            Vector2 newPosition = Vector2.SmoothDamp(current, target, ref velocity, positionSmoothTime, Mathf.Infinity, Time.unscaledDeltaTime);
+            card.anchoredPosition = newPosition;
+            _velocity[i] = velocity;
+        }
+    }
+}

--- a/Assets/Scripts/HandAreaHover.cs.meta
+++ b/Assets/Scripts/HandAreaHover.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d071dffd52ad401a8d3ccfd8b79aa983
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add a HandAreaHover behaviour that spaces cards, expands them on hover, and raises the hovered card
- attach the behaviour to the Hand Area prefab with public animation and layout controls

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ced0a59c6c832288d73663a7275fff