### PR TITLE
Fix card prefab to use RectTransform for hover

### DIFF
--- a/Assets/Prefabs/Card.prefab
+++ b/Assets/Prefabs/Card.prefab
@@ -143,29 +143,33 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5735851196013634290}
-  m_Layer: 0
+  m_Layer: 5
   m_Name: Card
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5735851196013634290
-Transform:
+--- !u!224 &5735851196013634290
+RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1244029720336922669}
-  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
+  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 9127481278510484744}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 210, y: 170}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &3834608840237841765
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Hand Area.prefab
+++ b/Assets/Prefabs/Hand Area.prefab
@@ -142,8 +142,8 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000000}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &2001000000000000000 stripped
-Transform:
+--- !u!224 &2001000000000000000 stripped
+RectTransform:
   m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000000}
   m_PrefabAsset: {fileID: 0}
@@ -225,8 +225,8 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000001}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &2001000000000000001 stripped
-Transform:
+--- !u!224 &2001000000000000001 stripped
+RectTransform:
   m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000001}
   m_PrefabAsset: {fileID: 0}
@@ -308,8 +308,8 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000002}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &2001000000000000002 stripped
-Transform:
+--- !u!224 &2001000000000000002 stripped
+RectTransform:
   m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000002}
   m_PrefabAsset: {fileID: 0}
@@ -391,8 +391,8 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000003}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &2001000000000000003 stripped
-Transform:
+--- !u!224 &2001000000000000003 stripped
+RectTransform:
   m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000003}
   m_PrefabAsset: {fileID: 0}
@@ -474,8 +474,8 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000004}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &2001000000000000004 stripped
-Transform:
+--- !u!224 &2001000000000000004 stripped
+RectTransform:
   m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000004}
   m_PrefabAsset: {fileID: 0}
@@ -557,8 +557,8 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000005}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &2001000000000000005 stripped
-Transform:
+--- !u!224 &2001000000000000005 stripped
+RectTransform:
   m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000005}
   m_PrefabAsset: {fileID: 0}
@@ -640,8 +640,8 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000006}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &2001000000000000006 stripped
-Transform:
+--- !u!224 &2001000000000000006 stripped
+RectTransform:
   m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000006}
   m_PrefabAsset: {fileID: 0}
@@ -723,8 +723,8 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000007}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &2001000000000000007 stripped
-Transform:
+--- !u!224 &2001000000000000007 stripped
+RectTransform:
   m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000007}
   m_PrefabAsset: {fileID: 0}
@@ -806,8 +806,8 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000008}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &2001000000000000008 stripped
-Transform:
+--- !u!224 &2001000000000000008 stripped
+RectTransform:
   m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000008}
   m_PrefabAsset: {fileID: 0}
@@ -889,8 +889,8 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000009}
   m_PrefabAsset: {fileID: 0}
---- !u!4 &2001000000000000009 stripped
-Transform:
+--- !u!224 &2001000000000000009 stripped
+RectTransform:
   m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
   m_PrefabInstance: {fileID: 1001000000000000009}
   m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
## Summary
- convert the Card prefab root from a Transform to a RectTransform so hover code can detect cards
- update the Hand Area prefab to reference the new RectTransform instances of the card prefab

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ced54ed3508322853144890e379376