### PR TITLE
Add draggable card behaviour and slot handling

### DIFF
--- a/Assets/Scripts/CardDragHandler.cs
+++ b/Assets/Scripts/CardDragHandler.cs
@@ -1,0 +1,112 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+[RequireComponent(typeof(RectTransform))]
+public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
+{
+    [Header("Dependencies")]
+    [Tooltip("Canvas used to position the card while it is being dragged. Defaults to the first parent canvas if not assigned.")]
+    public Canvas dragCanvas;
+
+    [Header("Behaviour")]
+    [Tooltip("If enabled the card returns to its previous slot when it is not dropped on a valid slot.")]
+    public bool returnToOriginalSlotIfRejected = true;
+
+    private RectTransform _rectTransform;
+    private CanvasGroup _canvasGroup;
+    private Vector3 _dragOffset;
+
+    private Transform _originalParent;
+    private int _originalSiblingIndex;
+    private Vector2 _originalAnchoredPosition;
+    private CardSlot _originalSlot;
+    private CardSlot _currentSlot;
+
+    private void Awake()
+    {
+        _rectTransform = GetComponent<RectTransform>();
+        _canvasGroup = GetComponent<CanvasGroup>();
+        if (_canvasGroup == null)
+        {
+            _canvasGroup = gameObject.AddComponent<CanvasGroup>();
+        }
+
+        if (dragCanvas == null)
+        {
+            dragCanvas = GetComponentInParent<Canvas>();
+        }
+
+        _currentSlot = GetComponentInParent<CardSlot>();
+    }
+
+    public void OnBeginDrag(PointerEventData eventData)
+    {
+        _originalParent = _rectTransform.parent;
+        _originalSiblingIndex = _rectTransform.GetSiblingIndex();
+        _originalAnchoredPosition = _rectTransform.anchoredPosition;
+        _originalSlot = _currentSlot;
+
+        _dragOffset = _rectTransform.position - (Vector3)eventData.position;
+
+        _canvasGroup.blocksRaycasts = false;
+
+        if (dragCanvas != null)
+        {
+            _rectTransform.SetParent(dragCanvas.transform, true);
+            _rectTransform.SetAsLastSibling();
+        }
+    }
+
+    public void OnDrag(PointerEventData eventData)
+    {
+        _rectTransform.position = eventData.position + _dragOffset;
+    }
+
+    public void OnEndDrag(PointerEventData eventData)
+    {
+        _canvasGroup.blocksRaycasts = true;
+
+        CardSlot targetSlot = null;
+        if (eventData.pointerEnter != null)
+        {
+            targetSlot = eventData.pointerEnter.GetComponentInParent<CardSlot>();
+        }
+
+        if (targetSlot != null && targetSlot.TryAccept(this))
+        {
+            return;
+        }
+
+        if (returnToOriginalSlotIfRejected)
+        {
+            RestoreOriginalPlacement();
+        }
+    }
+
+    public void RestoreOriginalPlacement()
+    {
+        _currentSlot = _originalSlot;
+
+        if (_originalParent != null)
+        {
+            _rectTransform.SetParent(_originalParent, false);
+            _rectTransform.SetSiblingIndex(_originalSiblingIndex);
+            _rectTransform.anchoredPosition = _originalAnchoredPosition;
+        }
+    }
+
+    public void CompleteSlotDrop(CardSlot slot, Transform parent, Vector2 anchoredPosition)
+    {
+        _currentSlot = slot;
+
+        if (parent != null)
+        {
+            _rectTransform.SetParent(parent, false);
+        }
+
+        _rectTransform.SetAsLastSibling();
+        _rectTransform.anchoredPosition = anchoredPosition;
+    }
+
+    public RectTransform RectTransform => _rectTransform;
+}

--- a/Assets/Scripts/CardDragHandler.cs.meta
+++ b/Assets/Scripts/CardDragHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d63796b76e7e422b97482d3afe76ff00
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CardSlot.cs
+++ b/Assets/Scripts/CardSlot.cs
@@ -1,0 +1,50 @@
+using UnityEngine;
+
+public class CardSlot : MonoBehaviour
+{
+    [Header("Slot Configuration")]
+    [Tooltip("Optional transform that will become the parent of any dropped cards. If empty, the card will be parented to this transform.")]
+    public Transform cardParent;
+
+    [Tooltip("When disabled only one card can be held by this slot at a time.")]
+    public bool allowMultipleCards = false;
+
+    [Tooltip("Anchored position applied to the card when it is dropped on this slot.")]
+    public Vector2 dropOffset = Vector2.zero;
+
+    private Transform CardParent => cardParent != null ? cardParent : transform;
+
+    public bool TryAccept(CardDragHandler card)
+    {
+        if (card == null)
+        {
+            return false;
+        }
+
+        if (!allowMultipleCards && HasAnotherCard(card))
+        {
+            return false;
+        }
+
+        card.CompleteSlotDrop(this, CardParent, dropOffset);
+        return true;
+    }
+
+    private bool HasAnotherCard(CardDragHandler ignoredCard)
+    {
+        foreach (Transform child in CardParent)
+        {
+            if (child == null || child == ignoredCard.transform)
+            {
+                continue;
+            }
+
+            if (child.GetComponent<CardDragHandler>() != null)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Assets/Scripts/CardSlot.cs.meta
+++ b/Assets/Scripts/CardSlot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00b4e7ec8ab6403c8ff5b1eaf8cc617b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add a reusable drag handler for UI cards that follows the pointer and reverts if no slot is targeted
- implement a slot component that accepts dropped cards and optionally restricts capacity

## Testing
- not run (Unity project, no automated tests available)


------
https://chatgpt.com/codex/tasks/task_e_68cedb327b648322967cefa3fc69a840