### PR TITLE
Refresh hand layout when cards move

### DIFF
--- a/Assets/Scripts/HandAreaHover.cs
+++ b/Assets/Scripts/HandAreaHover.cs
@@ -36,6 +36,11 @@ public class HandAreaHover : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
         CacheCards();
     }
 
+    private void OnTransformChildrenChanged()
+    {
+        CacheCards();
+    }
+
     public void OnPointerEnter(PointerEventData eventData)
     {
         _isHovered = true;


### PR DESCRIPTION
## Summary
- refresh the hand area card cache whenever its children change so only current cards are affected by hover logic

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cee106c90483229205aa21225a95c1