### PR TITLE
Dynamically update slot relationship labels

### DIFF
--- a/Assets/Prefabs/Slot Area.prefab
+++ b/Assets/Prefabs/Slot Area.prefab
@@ -99,7 +99,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Sample text
+  m_text: Akraba
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -270,7 +270,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Sample text
+  m_text: Kardeş
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -441,7 +441,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Sample text
+  m_text: Kardeş
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -612,7 +612,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Sample text
+  m_text: Eş
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -783,7 +783,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Sample text
+  m_text: Evlat
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -954,7 +954,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Sample text
+  m_text: Evlat
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -1035,6 +1035,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2647141232727049431}
+  - component: {fileID: 7464322585517025906}
   m_Layer: 0
   m_Name: Slot Area
   m_TagString: Untagged
@@ -1069,6 +1070,18 @@ Transform:
   - {fileID: 6671556896412499123}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7464322585517025906
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8187553421447118944}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 27867a85ad2b451f810b821e39da5220, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!1001 &1662036828156717437
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/SlotRelationshipDisplay.cs
+++ b/Assets/Scripts/SlotRelationshipDisplay.cs
@@ -1,0 +1,284 @@
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class SlotRelationshipDisplay : MonoBehaviour
+{
+    private readonly Dictionary<int, CardSlot> _slotsByIndex = new Dictionary<int, CardSlot>();
+    private readonly List<RelationshipConnection> _connections = new List<RelationshipConnection>();
+
+    private void Awake()
+    {
+        Initialize();
+        UpdateConnections();
+    }
+
+    private void OnEnable()
+    {
+        Initialize();
+        UpdateConnections();
+    }
+
+    private void Update()
+    {
+        UpdateConnections();
+    }
+
+    private void Initialize()
+    {
+        _slotsByIndex.Clear();
+        CacheSlots();
+
+        _connections.Clear();
+        CacheConnections();
+    }
+
+    private void CacheSlots()
+    {
+        var slots = GetComponentsInChildren<CardSlot>(true);
+        foreach (CardSlot slot in slots)
+        {
+            if (slot == null)
+            {
+                continue;
+            }
+
+            if (TryParseSlotIndex(slot.gameObject.name, out int index) && !_slotsByIndex.ContainsKey(index))
+            {
+                _slotsByIndex.Add(index, slot);
+            }
+        }
+    }
+
+    private void CacheConnections()
+    {
+        var texts = GetComponentsInChildren<TMP_Text>(true);
+        foreach (TMP_Text text in texts)
+        {
+            if (text == null)
+            {
+                continue;
+            }
+
+            if (!TryParseConnectionName(text.gameObject.name, out int fromIndex, out int toIndex))
+            {
+                continue;
+            }
+
+            if (!_slotsByIndex.TryGetValue(fromIndex, out CardSlot fromSlot))
+            {
+                continue;
+            }
+
+            if (!_slotsByIndex.TryGetValue(toIndex, out CardSlot toSlot))
+            {
+                continue;
+            }
+
+            _connections.Add(new RelationshipConnection(fromSlot, toSlot, text));
+        }
+    }
+
+    private void UpdateConnections()
+    {
+        if (_connections.Count == 0)
+        {
+            return;
+        }
+
+        foreach (RelationshipConnection connection in _connections)
+        {
+            UpdateConnection(connection);
+        }
+    }
+
+    private void UpdateConnection(RelationshipConnection connection)
+    {
+        if (connection == null)
+        {
+            return;
+        }
+
+        CharacterCardDefinition fromDefinition = GetCardDefinition(connection.FromSlot);
+        CharacterCardDefinition toDefinition = GetCardDefinition(connection.ToSlot);
+
+        if (fromDefinition != null && toDefinition != null)
+        {
+            string relation = ResolveRelationship(fromDefinition, toDefinition);
+            if (!string.IsNullOrWhiteSpace(relation))
+            {
+                SetConnectionActive(connection, true);
+                SetConnectionText(connection, relation);
+                return;
+            }
+        }
+
+        SetConnectionActive(connection, false);
+    }
+
+    private CharacterCardDefinition GetCardDefinition(CardSlot slot)
+    {
+        if (slot == null)
+        {
+            return null;
+        }
+
+        Transform parent = slot.GetCardParent();
+        if (parent == null)
+        {
+            return null;
+        }
+
+        for (int i = 0; i < parent.childCount; i++)
+        {
+            Transform child = parent.GetChild(i);
+            if (child == null)
+            {
+                continue;
+            }
+
+            CardDragHandler handler = child.GetComponent<CardDragHandler>();
+            if (handler == null)
+            {
+                continue;
+            }
+
+            if (handler.CurrentSlot != slot)
+            {
+                continue;
+            }
+
+            CardView view = handler.GetComponent<CardView>();
+            if (view == null)
+            {
+                continue;
+            }
+
+            if (!view.gameObject.activeInHierarchy)
+            {
+                continue;
+            }
+
+            return view.Definition;
+        }
+
+        return null;
+    }
+
+    private string ResolveRelationship(CharacterCardDefinition from, CharacterCardDefinition to)
+    {
+        if (from == null || to == null)
+        {
+            return string.Empty;
+        }
+
+        RelationshipInfo relationship = from.GetRelationshipById(to.id);
+        if (relationship != null && !string.IsNullOrWhiteSpace(relationship.relation))
+        {
+            return relationship.relation;
+        }
+
+        relationship = to.GetRelationshipById(from.id);
+        if (relationship != null && !string.IsNullOrWhiteSpace(relationship.relation))
+        {
+            return relationship.relation;
+        }
+
+        return string.Empty;
+    }
+
+    private void SetConnectionActive(RelationshipConnection connection, bool isActive)
+    {
+        if (connection.LastActive != isActive)
+        {
+            connection.LastActive = isActive;
+
+            if (connection.Label != null)
+            {
+                connection.Label.gameObject.SetActive(isActive);
+            }
+        }
+
+        if (!isActive)
+        {
+            SetConnectionText(connection, string.Empty);
+        }
+    }
+
+    private void SetConnectionText(RelationshipConnection connection, string text)
+    {
+        string newText = text ?? string.Empty;
+        if (string.Equals(connection.LastText, newText, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        connection.LastText = newText;
+
+        if (connection.Label != null)
+        {
+            connection.Label.text = newText;
+        }
+    }
+
+    private bool TryParseSlotIndex(string name, out int index)
+    {
+        index = 0;
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return false;
+        }
+
+        const string prefix = "Slot ";
+        if (!name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        string suffix = name.Substring(prefix.Length).Trim();
+        return int.TryParse(suffix, out index);
+    }
+
+    private bool TryParseConnectionName(string name, out int fromIndex, out int toIndex)
+    {
+        fromIndex = 0;
+        toIndex = 0;
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return false;
+        }
+
+        string trimmed = name.Trim();
+        int separatorIndex = trimmed.IndexOf(" to ", StringComparison.OrdinalIgnoreCase);
+        if (separatorIndex <= 0)
+        {
+            return false;
+        }
+
+        string fromPart = trimmed.Substring(0, separatorIndex).Trim();
+        string toPart = trimmed.Substring(separatorIndex + 4).Trim();
+
+        return int.TryParse(fromPart, out fromIndex) && int.TryParse(toPart, out toIndex);
+    }
+
+    private sealed class RelationshipConnection
+    {
+        public RelationshipConnection(CardSlot fromSlot, CardSlot toSlot, TMP_Text label)
+        {
+            FromSlot = fromSlot;
+            ToSlot = toSlot;
+            Label = label;
+            LastActive = label != null && label.gameObject.activeSelf;
+            LastText = label != null ? label.text : string.Empty;
+        }
+
+        public CardSlot FromSlot { get; }
+        public CardSlot ToSlot { get; }
+        public TMP_Text Label { get; }
+        public bool LastActive { get; set; }
+        public string LastText { get; set; }
+    }
+}

--- a/Assets/Scripts/SlotRelationshipDisplay.cs.meta
+++ b/Assets/Scripts/SlotRelationshipDisplay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27867a85ad2b451f810b821e39da5220
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add a SlotRelationshipDisplay script that maps slots and connector labels, resolving the current relationship between placed cards
- attach the display script to the Slot Area prefab so relationship texts activate only when both linked slots contain cards

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68cf073ee3d0832292abd2a907d715b7