### PR TITLE
Add hand card preview functionality

### DIFF
--- a/Assets/Resources/Prefabs/CardPreview.prefab
+++ b/Assets/Resources/Prefabs/CardPreview.prefab
@@ -1,0 +1,117 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &919572769822133245
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 921030583964314964}
+  m_Layer: 5
+  m_Name: CardPreview
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &921030583964314964
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 919572769822133245}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2001000000000000010}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1001 &1001000000000000010
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 921030583964314964}
+    m_Modifications:
+    - target: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_Name
+      value: Card
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3547998242888599151, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+--- !u!1 &3001000000000000011 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1244029720336922669, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000010}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &2001000000000000010 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5735851196013634290, guid: d6a4ecc9f8aa38a4581a9bb9a1f94163, type: 3}
+  m_PrefabInstance: {fileID: 1001000000000000010}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Resources/Prefabs/CardPreview.prefab.meta
+++ b/Assets/Resources/Prefabs/CardPreview.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f4f02261d553417897aa82cb01300cc7
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add a CardPreview prefab that instantiates the existing card visuals at a larger scale for previews
- extend HandAreaHover to load the preview prefab, resolve a display container, and manage showing or hiding the hovered card preview

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68cf0fcdc0cc8322968419f9ffaee131