### PR TITLE
Highlight slot relationships on hover

### DIFF
--- a/Assets/Scripts/CardDragHandler.cs
+++ b/Assets/Scripts/CardDragHandler.cs
@@ -1,8 +1,9 @@
+using System;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
 [RequireComponent(typeof(RectTransform))]
-public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
+public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler, IPointerEnterHandler, IPointerExitHandler
 {
     [Header("Dependencies")]
     [Tooltip("Canvas used to position the card while it is being dragged. Defaults to the first parent canvas if not assigned.")]
@@ -24,6 +25,9 @@ public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
 
     private bool _isDragging;
 
+    public static event Action<CardDragHandler> PointerEntered;
+    public static event Action<CardDragHandler> PointerExited;
+
     private void Awake()
     {
         _rectTransform = GetComponent<RectTransform>();
@@ -44,6 +48,10 @@ public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
     public void OnBeginDrag(PointerEventData eventData)
     {
         _isDragging = true;
+        if (_currentSlot != null)
+        {
+            PointerExited?.Invoke(this);
+        }
         _originalParent = _rectTransform.parent;
         _originalSiblingIndex = _rectTransform.GetSiblingIndex();
         _originalAnchoredPosition = _rectTransform.anchoredPosition;
@@ -144,6 +152,26 @@ public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
     public int OriginalSiblingIndex => _originalSiblingIndex;
     public Vector2 OriginalAnchoredPosition => _originalAnchoredPosition;
     public bool IsDragging => _isDragging;
+
+    public void OnPointerEnter(PointerEventData eventData)
+    {
+        if (_isDragging || _currentSlot == null)
+        {
+            return;
+        }
+
+        PointerEntered?.Invoke(this);
+    }
+
+    public void OnPointerExit(PointerEventData eventData)
+    {
+        if (_isDragging || _currentSlot == null)
+        {
+            return;
+        }
+
+        PointerExited?.Invoke(this);
+    }
 
     private Vector3 GetPointerWorldPosition(PointerEventData eventData)
     {

--- a/Assets/Scripts/CardSlot.cs
+++ b/Assets/Scripts/CardSlot.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 public class CardSlot : MonoBehaviour
@@ -12,11 +13,80 @@ public class CardSlot : MonoBehaviour
     [Tooltip("Anchored position applied to the card when it is dropped on this slot.")]
     public Vector2 dropOffset = Vector2.zero;
 
+    [Header("Visuals")]
+    [Tooltip("Optional object that is activated to highlight this slot. Defaults to a child named 'Glow'.")]
+    [SerializeField]
+    private GameObject glowRoot;
+
     private Transform CardParent => cardParent != null ? cardParent : transform;
 
     public Transform GetCardParent()
     {
         return CardParent;
+    }
+
+    private void Awake()
+    {
+        EnsureGlowReference();
+        SetGlowActive(false);
+    }
+
+    private void Reset()
+    {
+        EnsureGlowReference();
+        SetGlowActive(false);
+    }
+
+    private void OnEnable()
+    {
+        EnsureGlowReference();
+        SetGlowActive(false);
+    }
+
+    private void EnsureGlowReference()
+    {
+        if (glowRoot != null)
+        {
+            return;
+        }
+
+        Transform found = transform.Find("Glow");
+        if (found == null)
+        {
+            for (int i = 0; i < transform.childCount; i++)
+            {
+                Transform child = transform.GetChild(i);
+                if (child == null)
+                {
+                    continue;
+                }
+
+                if (string.Equals(child.name, "Glow", StringComparison.OrdinalIgnoreCase))
+                {
+                    found = child;
+                    break;
+                }
+            }
+        }
+
+        if (found != null)
+        {
+            glowRoot = found.gameObject;
+        }
+    }
+
+    public void SetGlowActive(bool isActive)
+    {
+        EnsureGlowReference();
+        if (glowRoot == null)
+        {
+            return;
+        }
+
+        if (glowRoot.activeSelf != isActive)
+        {
+            glowRoot.SetActive(isActive);
+        }
     }
 
     public bool TryAccept(CardDragHandler card)


### PR DESCRIPTION
## Summary
- add glow management helpers to card slots so their highlight sprite can be controlled in code
- raise pointer enter / exit events from cards that are sitting in slots
- only display relationship labels and slot glow while hovering a related card in the slot area

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68cf31ca7a308322aa20b8ae90318daa