### PR TITLE
Update slot relationship highlights for hand hover

### DIFF
--- a/Assets/Scripts/CardDragHandler.cs
+++ b/Assets/Scripts/CardDragHandler.cs
@@ -1,8 +1,9 @@
+using System;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
 [RequireComponent(typeof(RectTransform))]
-public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
+public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler, IPointerEnterHandler, IPointerExitHandler
 {
     [Header("Dependencies")]
     [Tooltip("Canvas used to position the card while it is being dragged. Defaults to the first parent canvas if not assigned.")]
@@ -24,6 +25,9 @@ public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
 
     private bool _isDragging;
 
+    public static event Action<CardDragHandler> PointerEntered;
+    public static event Action<CardDragHandler> PointerExited;
+
     private void Awake()
     {
         _rectTransform = GetComponent<RectTransform>();
@@ -44,6 +48,7 @@ public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
     public void OnBeginDrag(PointerEventData eventData)
     {
         _isDragging = true;
+        PointerExited?.Invoke(this);
         _originalParent = _rectTransform.parent;
         _originalSiblingIndex = _rectTransform.GetSiblingIndex();
         _originalAnchoredPosition = _rectTransform.anchoredPosition;
@@ -144,6 +149,26 @@ public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
     public int OriginalSiblingIndex => _originalSiblingIndex;
     public Vector2 OriginalAnchoredPosition => _originalAnchoredPosition;
     public bool IsDragging => _isDragging;
+
+    public void OnPointerEnter(PointerEventData eventData)
+    {
+        if (_isDragging)
+        {
+            return;
+        }
+
+        PointerEntered?.Invoke(this);
+    }
+
+    public void OnPointerExit(PointerEventData eventData)
+    {
+        if (_isDragging)
+        {
+            return;
+        }
+
+        PointerExited?.Invoke(this);
+    }
 
     private Vector3 GetPointerWorldPosition(PointerEventData eventData)
     {

--- a/Assets/Scripts/CardSlot.cs
+++ b/Assets/Scripts/CardSlot.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 public class CardSlot : MonoBehaviour
@@ -12,11 +13,80 @@ public class CardSlot : MonoBehaviour
     [Tooltip("Anchored position applied to the card when it is dropped on this slot.")]
     public Vector2 dropOffset = Vector2.zero;
 
+    [Header("Visuals")]
+    [Tooltip("Optional object that is activated to highlight this slot. Defaults to a child named 'Glow'.")]
+    [SerializeField]
+    private GameObject glowRoot;
+
     private Transform CardParent => cardParent != null ? cardParent : transform;
 
     public Transform GetCardParent()
     {
         return CardParent;
+    }
+
+    private void Awake()
+    {
+        EnsureGlowReference();
+        SetGlowActive(false);
+    }
+
+    private void Reset()
+    {
+        EnsureGlowReference();
+        SetGlowActive(false);
+    }
+
+    private void OnEnable()
+    {
+        EnsureGlowReference();
+        SetGlowActive(false);
+    }
+
+    private void EnsureGlowReference()
+    {
+        if (glowRoot != null)
+        {
+            return;
+        }
+
+        Transform found = transform.Find("Glow");
+        if (found == null)
+        {
+            for (int i = 0; i < transform.childCount; i++)
+            {
+                Transform child = transform.GetChild(i);
+                if (child == null)
+                {
+                    continue;
+                }
+
+                if (string.Equals(child.name, "Glow", StringComparison.OrdinalIgnoreCase))
+                {
+                    found = child;
+                    break;
+                }
+            }
+        }
+
+        if (found != null)
+        {
+            glowRoot = found.gameObject;
+        }
+    }
+
+    public void SetGlowActive(bool isActive)
+    {
+        EnsureGlowReference();
+        if (glowRoot == null)
+        {
+            return;
+        }
+
+        if (glowRoot.activeSelf != isActive)
+        {
+            glowRoot.SetActive(isActive);
+        }
     }
 
     public bool TryAccept(CardDragHandler card)

--- a/Assets/Scripts/SlotRelationshipDisplay.cs
+++ b/Assets/Scripts/SlotRelationshipDisplay.cs
@@ -7,7 +7,11 @@ using UnityEngine;
 public class SlotRelationshipDisplay : MonoBehaviour
 {
     private readonly Dictionary<int, CardSlot> _slotsByIndex = new Dictionary<int, CardSlot>();
+    private readonly List<CardSlot> _allSlots = new List<CardSlot>();
     private readonly List<RelationshipConnection> _connections = new List<RelationshipConnection>();
+
+    private CardDragHandler _hoveredCard;
+    private CharacterCardDefinition _hoveredCardDefinition;
 
     private void Awake()
     {
@@ -17,7 +21,20 @@ public class SlotRelationshipDisplay : MonoBehaviour
 
     private void OnEnable()
     {
+        CardDragHandler.PointerEntered += HandleCardPointerEnter;
+        CardDragHandler.PointerExited += HandleCardPointerExit;
+
         Initialize();
+        UpdateConnections();
+    }
+
+    private void OnDisable()
+    {
+        CardDragHandler.PointerEntered -= HandleCardPointerEnter;
+        CardDragHandler.PointerExited -= HandleCardPointerExit;
+
+        _hoveredCard = null;
+        _hoveredCardDefinition = null;
         UpdateConnections();
     }
 
@@ -29,10 +46,18 @@ public class SlotRelationshipDisplay : MonoBehaviour
     private void Initialize()
     {
         _slotsByIndex.Clear();
+        _allSlots.Clear();
         CacheSlots();
 
         _connections.Clear();
         CacheConnections();
+
+        foreach (RelationshipConnection connection in _connections)
+        {
+            SetConnectionActive(connection, false);
+        }
+
+        UpdateSlotGlows(null);
     }
 
     private void CacheSlots()
@@ -48,6 +73,11 @@ public class SlotRelationshipDisplay : MonoBehaviour
             if (TryParseSlotIndex(slot.gameObject.name, out int index) && !_slotsByIndex.ContainsKey(index))
             {
                 _slotsByIndex.Add(index, slot);
+            }
+
+            if (!_allSlots.Contains(slot))
+            {
+                _allSlots.Add(slot);
             }
         }
     }
@@ -85,13 +115,37 @@ public class SlotRelationshipDisplay : MonoBehaviour
     {
         if (_connections.Count == 0)
         {
+            UpdateSlotGlows(null);
             return;
         }
 
+        HashSet<CardSlot> highlightedSlots = null;
         foreach (RelationshipConnection connection in _connections)
         {
             UpdateConnection(connection);
+
+            if (!connection.HighlightFrom && !connection.HighlightTo)
+            {
+                continue;
+            }
+
+            if (highlightedSlots == null)
+            {
+                highlightedSlots = new HashSet<CardSlot>();
+            }
+
+            if (connection.HighlightFrom && connection.FromSlot != null)
+            {
+                highlightedSlots.Add(connection.FromSlot);
+            }
+
+            if (connection.HighlightTo && connection.ToSlot != null)
+            {
+                highlightedSlots.Add(connection.ToSlot);
+            }
         }
+
+        UpdateSlotGlows(highlightedSlots);
     }
 
     private void UpdateConnection(RelationshipConnection connection)
@@ -103,19 +157,117 @@ public class SlotRelationshipDisplay : MonoBehaviour
 
         CharacterCardDefinition fromDefinition = GetCardDefinition(connection.FromSlot);
         CharacterCardDefinition toDefinition = GetCardDefinition(connection.ToSlot);
+        CharacterCardDefinition hoveredDefinition = _hoveredCardDefinition;
 
+        string slotRelation = string.Empty;
         if (fromDefinition != null && toDefinition != null)
         {
-            string relation = ResolveRelationship(fromDefinition, toDefinition);
-            if (!string.IsNullOrWhiteSpace(relation))
+            slotRelation = ResolveRelationship(fromDefinition, toDefinition);
+        }
+
+        string hoverRelation = string.Empty;
+        bool hoverMatchesEitherSlot = false;
+        if (hoveredDefinition != null)
+        {
+            if (fromDefinition != null)
             {
-                SetConnectionActive(connection, true);
-                SetConnectionText(connection, relation);
-                return;
+                string relationWithFrom = ResolveRelationship(hoveredDefinition, fromDefinition);
+                if (!string.IsNullOrWhiteSpace(relationWithFrom))
+                {
+                    hoverMatchesEitherSlot = true;
+                    hoverRelation = relationWithFrom;
+                }
+            }
+
+            if (toDefinition != null)
+            {
+                string relationWithTo = ResolveRelationship(hoveredDefinition, toDefinition);
+                if (!string.IsNullOrWhiteSpace(relationWithTo))
+                {
+                    hoverMatchesEitherSlot = true;
+                    if (string.IsNullOrEmpty(hoverRelation))
+                    {
+                        hoverRelation = relationWithTo;
+                    }
+                }
             }
         }
 
-        SetConnectionActive(connection, false);
+        bool slotsHaveRelationship = !string.IsNullOrWhiteSpace(slotRelation);
+        bool hoverProvidesRelationship = !string.IsNullOrWhiteSpace(hoverRelation);
+
+        string relationToDisplay = slotsHaveRelationship ? slotRelation : hoverRelation;
+        bool shouldDisplayLabel = slotsHaveRelationship || hoverProvidesRelationship;
+
+        connection.RelationshipText = relationToDisplay;
+        connection.HighlightFrom = hoverMatchesEitherSlot && connection.FromSlot != null;
+        connection.HighlightTo = hoverMatchesEitherSlot && connection.ToSlot != null;
+
+        SetConnectionActive(connection, shouldDisplayLabel);
+
+        if (shouldDisplayLabel)
+        {
+            SetConnectionText(connection, relationToDisplay);
+        }
+    }
+
+    private void UpdateSlotGlows(ISet<CardSlot> highlightedSlots)
+    {
+        foreach (CardSlot slot in _allSlots)
+        {
+            if (slot == null)
+            {
+                continue;
+            }
+
+            bool shouldGlow = highlightedSlots != null && highlightedSlots.Contains(slot);
+            slot.SetGlowActive(shouldGlow);
+        }
+    }
+
+    private void HandleCardPointerEnter(CardDragHandler handler)
+    {
+        if (handler == null)
+        {
+            return;
+        }
+
+        if (!IsHandCard(handler))
+        {
+            return;
+        }
+
+        CharacterCardDefinition definition = GetCardDefinition(handler);
+        if (definition == null)
+        {
+            return;
+        }
+
+        _hoveredCard = handler;
+        _hoveredCardDefinition = definition;
+        UpdateConnections();
+    }
+
+    private void HandleCardPointerExit(CardDragHandler handler)
+    {
+        if (handler == null || handler != _hoveredCard)
+        {
+            return;
+        }
+
+        _hoveredCard = null;
+        _hoveredCardDefinition = null;
+        UpdateConnections();
+    }
+
+    private bool IsHandCard(CardDragHandler handler)
+    {
+        if (handler == null)
+        {
+            return false;
+        }
+
+        return handler.GetComponentInParent<HandAreaHover>() != null;
     }
 
     private CharacterCardDefinition GetCardDefinition(CardSlot slot)
@@ -165,6 +317,27 @@ public class SlotRelationshipDisplay : MonoBehaviour
         }
 
         return null;
+    }
+
+    private CharacterCardDefinition GetCardDefinition(CardDragHandler handler)
+    {
+        if (handler == null)
+        {
+            return null;
+        }
+
+        CardView view = handler.GetComponent<CardView>();
+        if (view == null)
+        {
+            view = handler.GetComponentInChildren<CardView>();
+        }
+
+        if (view == null || !view.gameObject.activeInHierarchy)
+        {
+            return null;
+        }
+
+        return view.Definition;
     }
 
     private string ResolveRelationship(CharacterCardDefinition from, CharacterCardDefinition to)
@@ -280,5 +453,8 @@ public class SlotRelationshipDisplay : MonoBehaviour
         public TMP_Text Label { get; }
         public bool LastActive { get; set; }
         public string LastText { get; set; }
+        public string RelationshipText { get; set; }
+        public bool HighlightFrom { get; set; }
+        public bool HighlightTo { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- allow card hover events to fire for cards in the hand and clear relationship hints when a drag begins
- drive slot relationship visuals from hovered hand cards so related slot glows and labels appear as the player inspects their hand
- keep relationship labels visible once both slots contain related cards while limiting glow highlights to the active hover

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68cf31ca7a308322aa20b8ae90318daa