### PR TITLE
Fix slot relationship hover logic

### DIFF
--- a/Assets/Scripts/CardDragHandler.cs
+++ b/Assets/Scripts/CardDragHandler.cs
@@ -1,8 +1,9 @@
+using System;
 using UnityEngine;
 using UnityEngine.EventSystems;
 
 [RequireComponent(typeof(RectTransform))]
-public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
+public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler, IPointerEnterHandler, IPointerExitHandler
 {
     [Header("Dependencies")]
     [Tooltip("Canvas used to position the card while it is being dragged. Defaults to the first parent canvas if not assigned.")]
@@ -24,6 +25,11 @@ public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
 
     private bool _isDragging;
 
+    public static event Action<CardDragHandler> PointerEntered;
+    public static event Action<CardDragHandler> PointerExited;
+    public static event Action<CardDragHandler> DragStarted;
+    public static event Action<CardDragHandler> DragEnded;
+
     private void Awake()
     {
         _rectTransform = GetComponent<RectTransform>();
@@ -44,6 +50,8 @@ public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
     public void OnBeginDrag(PointerEventData eventData)
     {
         _isDragging = true;
+        PointerExited?.Invoke(this);
+        DragStarted?.Invoke(this);
         _originalParent = _rectTransform.parent;
         _originalSiblingIndex = _rectTransform.GetSiblingIndex();
         _originalAnchoredPosition = _rectTransform.anchoredPosition;
@@ -71,6 +79,7 @@ public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
     {
         _isDragging = false;
         _canvasGroup.blocksRaycasts = true;
+        DragEnded?.Invoke(this);
 
         CardSlot targetSlot = null;
         if (eventData.pointerEnter != null)
@@ -144,6 +153,26 @@ public class CardDragHandler : MonoBehaviour, IBeginDragHandler, IDragHandler, I
     public int OriginalSiblingIndex => _originalSiblingIndex;
     public Vector2 OriginalAnchoredPosition => _originalAnchoredPosition;
     public bool IsDragging => _isDragging;
+
+    public void OnPointerEnter(PointerEventData eventData)
+    {
+        if (_isDragging)
+        {
+            return;
+        }
+
+        PointerEntered?.Invoke(this);
+    }
+
+    public void OnPointerExit(PointerEventData eventData)
+    {
+        if (_isDragging)
+        {
+            return;
+        }
+
+        PointerExited?.Invoke(this);
+    }
 
     private Vector3 GetPointerWorldPosition(PointerEventData eventData)
     {

--- a/Assets/Scripts/CardSlot.cs
+++ b/Assets/Scripts/CardSlot.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 public class CardSlot : MonoBehaviour
@@ -12,11 +13,80 @@ public class CardSlot : MonoBehaviour
     [Tooltip("Anchored position applied to the card when it is dropped on this slot.")]
     public Vector2 dropOffset = Vector2.zero;
 
+    [Header("Visuals")]
+    [Tooltip("Optional object that is activated to highlight this slot. Defaults to a child named 'Glow'.")]
+    [SerializeField]
+    private GameObject glowRoot;
+
     private Transform CardParent => cardParent != null ? cardParent : transform;
 
     public Transform GetCardParent()
     {
         return CardParent;
+    }
+
+    private void Awake()
+    {
+        EnsureGlowReference();
+        SetGlowActive(false);
+    }
+
+    private void Reset()
+    {
+        EnsureGlowReference();
+        SetGlowActive(false);
+    }
+
+    private void OnEnable()
+    {
+        EnsureGlowReference();
+        SetGlowActive(false);
+    }
+
+    private void EnsureGlowReference()
+    {
+        if (glowRoot != null)
+        {
+            return;
+        }
+
+        Transform found = transform.Find("Glow");
+        if (found == null)
+        {
+            for (int i = 0; i < transform.childCount; i++)
+            {
+                Transform child = transform.GetChild(i);
+                if (child == null)
+                {
+                    continue;
+                }
+
+                if (string.Equals(child.name, "Glow", StringComparison.OrdinalIgnoreCase))
+                {
+                    found = child;
+                    break;
+                }
+            }
+        }
+
+        if (found != null)
+        {
+            glowRoot = found.gameObject;
+        }
+    }
+
+    public void SetGlowActive(bool isActive)
+    {
+        EnsureGlowReference();
+        if (glowRoot == null)
+        {
+            return;
+        }
+
+        if (glowRoot.activeSelf != isActive)
+        {
+            glowRoot.SetActive(isActive);
+        }
     }
 
     public bool TryAccept(CardDragHandler card)

--- a/Assets/Scripts/SlotRelationshipDisplay.cs
+++ b/Assets/Scripts/SlotRelationshipDisplay.cs
@@ -7,7 +7,16 @@ using UnityEngine;
 public class SlotRelationshipDisplay : MonoBehaviour
 {
     private readonly Dictionary<int, CardSlot> _slotsByIndex = new Dictionary<int, CardSlot>();
+    private readonly List<CardSlot> _allSlots = new List<CardSlot>();
     private readonly List<RelationshipConnection> _connections = new List<RelationshipConnection>();
+
+    private CardDragHandler _hoveredCard;
+    private CharacterCardDefinition _hoveredCardDefinition;
+    private CardDragHandler _hoveredBoardCard;
+    private CharacterCardDefinition _hoveredBoardDefinition;
+    private CardSlot _hoveredBoardSlot;
+    private CardDragHandler _draggedCard;
+    private CharacterCardDefinition _draggedCardDefinition;
 
     private void Awake()
     {
@@ -17,7 +26,23 @@ public class SlotRelationshipDisplay : MonoBehaviour
 
     private void OnEnable()
     {
+        CardDragHandler.PointerEntered += HandleCardPointerEnter;
+        CardDragHandler.PointerExited += HandleCardPointerExit;
+        CardDragHandler.DragStarted += HandleCardDragStarted;
+        CardDragHandler.DragEnded += HandleCardDragEnded;
+
         Initialize();
+        UpdateConnections();
+    }
+
+    private void OnDisable()
+    {
+        CardDragHandler.PointerEntered -= HandleCardPointerEnter;
+        CardDragHandler.PointerExited -= HandleCardPointerExit;
+        CardDragHandler.DragStarted -= HandleCardDragStarted;
+        CardDragHandler.DragEnded -= HandleCardDragEnded;
+
+        ClearHoverStates();
         UpdateConnections();
     }
 
@@ -28,11 +53,20 @@ public class SlotRelationshipDisplay : MonoBehaviour
 
     private void Initialize()
     {
+        ClearHoverStates();
         _slotsByIndex.Clear();
+        _allSlots.Clear();
         CacheSlots();
 
         _connections.Clear();
         CacheConnections();
+
+        foreach (RelationshipConnection connection in _connections)
+        {
+            SetConnectionActive(connection, false);
+        }
+
+        UpdateSlotGlows(null);
     }
 
     private void CacheSlots()
@@ -48,6 +82,11 @@ public class SlotRelationshipDisplay : MonoBehaviour
             if (TryParseSlotIndex(slot.gameObject.name, out int index) && !_slotsByIndex.ContainsKey(index))
             {
                 _slotsByIndex.Add(index, slot);
+            }
+
+            if (!_allSlots.Contains(slot))
+            {
+                _allSlots.Add(slot);
             }
         }
     }
@@ -85,37 +124,296 @@ public class SlotRelationshipDisplay : MonoBehaviour
     {
         if (_connections.Count == 0)
         {
+            UpdateSlotGlows(null);
             return;
         }
 
+        HashSet<CardSlot> highlightedSlots = null;
         foreach (RelationshipConnection connection in _connections)
         {
             UpdateConnection(connection);
+
+            if (!connection.HighlightFrom && !connection.HighlightTo)
+            {
+                continue;
+            }
+
+            if (highlightedSlots == null)
+            {
+                highlightedSlots = new HashSet<CardSlot>();
+            }
+
+            if (connection.HighlightFrom && connection.FromSlot != null)
+            {
+                highlightedSlots.Add(connection.FromSlot);
+            }
+
+            if (connection.HighlightTo && connection.ToSlot != null)
+            {
+                highlightedSlots.Add(connection.ToSlot);
+            }
         }
+
+        UpdateSlotGlows(highlightedSlots);
     }
 
-    private void UpdateConnection(RelationshipConnection connection)
+    private bool UpdateConnection(RelationshipConnection connection)
     {
         if (connection == null)
         {
-            return;
+            return false;
         }
 
         CharacterCardDefinition fromDefinition = GetCardDefinition(connection.FromSlot);
         CharacterCardDefinition toDefinition = GetCardDefinition(connection.ToSlot);
-
+        string slotRelation = string.Empty;
         if (fromDefinition != null && toDefinition != null)
         {
-            string relation = ResolveRelationship(fromDefinition, toDefinition);
-            if (!string.IsNullOrWhiteSpace(relation))
+            slotRelation = ResolveRelationship(fromDefinition, toDefinition);
+        }
+
+        CharacterCardDefinition activeDefinition = _hoveredCardDefinition ?? _draggedCardDefinition;
+        CardSlot focusedSlot = _hoveredBoardSlot;
+
+        string relationWithFrom = string.Empty;
+        string relationWithTo = string.Empty;
+        bool activeMatchesFrom = false;
+        bool activeMatchesTo = false;
+
+        if (activeDefinition != null)
+        {
+            if (fromDefinition != null)
             {
-                SetConnectionActive(connection, true);
-                SetConnectionText(connection, relation);
-                return;
+                relationWithFrom = ResolveRelationship(activeDefinition, fromDefinition);
+                activeMatchesFrom = !string.IsNullOrWhiteSpace(relationWithFrom);
+            }
+
+            if (toDefinition != null)
+            {
+                relationWithTo = ResolveRelationship(activeDefinition, toDefinition);
+                activeMatchesTo = !string.IsNullOrWhiteSpace(relationWithTo);
+            }
+
+            if (focusedSlot != null)
+            {
+                if (connection.FromSlot != focusedSlot)
+                {
+                    activeMatchesFrom = false;
+                }
+
+                if (connection.ToSlot != focusedSlot)
+                {
+                    activeMatchesTo = false;
+                }
             }
         }
 
-        SetConnectionActive(connection, false);
+        bool slotsHaveRelationship = !string.IsNullOrWhiteSpace(slotRelation);
+        bool hoverProvidesRelationship = activeMatchesFrom || activeMatchesTo;
+
+        string relationToDisplay = slotRelation;
+        if (string.IsNullOrWhiteSpace(relationToDisplay))
+        {
+            if (activeMatchesFrom)
+            {
+                relationToDisplay = relationWithFrom;
+            }
+            else if (activeMatchesTo)
+            {
+                relationToDisplay = relationWithTo;
+            }
+        }
+
+        bool highlightFrom = false;
+        bool highlightTo = false;
+
+        if (activeMatchesFrom)
+        {
+            if (connection.FromSlot != null)
+            {
+                highlightFrom = true;
+            }
+
+            if (connection.ToSlot != null)
+            {
+                highlightTo = true;
+            }
+        }
+
+        if (activeMatchesTo)
+        {
+            if (connection.ToSlot != null)
+            {
+                highlightTo = true;
+            }
+
+            if (connection.FromSlot != null)
+            {
+                highlightFrom = true;
+            }
+        }
+
+        bool shouldDisplayLabel = slotsHaveRelationship || hoverProvidesRelationship;
+
+        connection.RelationshipText = relationToDisplay;
+        connection.HighlightFrom = highlightFrom;
+        connection.HighlightTo = highlightTo;
+
+        SetConnectionActive(connection, shouldDisplayLabel);
+
+        if (shouldDisplayLabel)
+        {
+            SetConnectionText(connection, relationToDisplay);
+        }
+
+        return shouldDisplayLabel;
+    }
+
+    private void UpdateSlotGlows(ISet<CardSlot> highlightedSlots)
+    {
+        foreach (CardSlot slot in _allSlots)
+        {
+            if (slot == null)
+            {
+                continue;
+            }
+
+            bool shouldGlow = highlightedSlots != null && highlightedSlots.Contains(slot);
+            slot.SetGlowActive(shouldGlow);
+        }
+    }
+
+    private void HandleCardPointerEnter(CardDragHandler handler)
+    {
+        if (handler == null)
+        {
+            return;
+        }
+
+        if (handler == _draggedCard)
+        {
+            return;
+        }
+
+        if (IsHandCard(handler))
+        {
+            CharacterCardDefinition definition = GetCardDefinition(handler);
+            if (definition == null)
+            {
+                return;
+            }
+
+            _hoveredCard = handler;
+            _hoveredCardDefinition = definition;
+            _hoveredBoardCard = null;
+            _hoveredBoardDefinition = null;
+            _hoveredBoardSlot = null;
+            UpdateConnections();
+            return;
+        }
+
+        if (_draggedCardDefinition == null)
+        {
+            return;
+        }
+
+        CardSlot slot = handler.CurrentSlot;
+        if (slot == null)
+        {
+            return;
+        }
+
+        CharacterCardDefinition boardDefinition = GetCardDefinition(handler);
+        if (boardDefinition == null)
+        {
+            return;
+        }
+
+        _hoveredBoardCard = handler;
+        _hoveredBoardDefinition = boardDefinition;
+        _hoveredBoardSlot = slot;
+        UpdateConnections();
+    }
+
+    private void HandleCardPointerExit(CardDragHandler handler)
+    {
+        if (handler == null)
+        {
+            return;
+        }
+
+        bool stateChanged = false;
+
+        if (handler == _hoveredCard)
+        {
+            _hoveredCard = null;
+            _hoveredCardDefinition = null;
+            stateChanged = true;
+        }
+
+        if (handler == _hoveredBoardCard)
+        {
+            _hoveredBoardCard = null;
+            _hoveredBoardDefinition = null;
+            _hoveredBoardSlot = null;
+            stateChanged = true;
+        }
+
+        if (stateChanged)
+        {
+            UpdateConnections();
+        }
+    }
+
+    private void HandleCardDragStarted(CardDragHandler handler)
+    {
+        if (handler == null)
+        {
+            return;
+        }
+
+        _draggedCard = handler;
+        _draggedCardDefinition = GetCardDefinition(handler);
+
+        if (_hoveredCard == handler)
+        {
+            _hoveredCard = null;
+            _hoveredCardDefinition = null;
+        }
+
+        if (_hoveredBoardCard == handler)
+        {
+            _hoveredBoardCard = null;
+            _hoveredBoardDefinition = null;
+            _hoveredBoardSlot = null;
+        }
+
+        UpdateConnections();
+    }
+
+    private void HandleCardDragEnded(CardDragHandler handler)
+    {
+        if (handler == null || handler != _draggedCard)
+        {
+            return;
+        }
+
+        _draggedCard = null;
+        _draggedCardDefinition = null;
+        _hoveredBoardCard = null;
+        _hoveredBoardDefinition = null;
+        _hoveredBoardSlot = null;
+        UpdateConnections();
+    }
+
+    private bool IsHandCard(CardDragHandler handler)
+    {
+        if (handler == null)
+        {
+            return false;
+        }
+
+        return handler.GetComponentInParent<HandAreaHover>() != null;
     }
 
     private CharacterCardDefinition GetCardDefinition(CardSlot slot)
@@ -165,6 +463,27 @@ public class SlotRelationshipDisplay : MonoBehaviour
         }
 
         return null;
+    }
+
+    private CharacterCardDefinition GetCardDefinition(CardDragHandler handler)
+    {
+        if (handler == null)
+        {
+            return null;
+        }
+
+        CardView view = handler.GetComponent<CardView>();
+        if (view == null)
+        {
+            view = handler.GetComponentInChildren<CardView>();
+        }
+
+        if (view == null || !view.gameObject.activeInHierarchy)
+        {
+            return null;
+        }
+
+        return view.Definition;
     }
 
     private string ResolveRelationship(CharacterCardDefinition from, CharacterCardDefinition to)
@@ -221,6 +540,17 @@ public class SlotRelationshipDisplay : MonoBehaviour
         {
             connection.Label.text = newText;
         }
+    }
+
+    private void ClearHoverStates()
+    {
+        _hoveredCard = null;
+        _hoveredCardDefinition = null;
+        _hoveredBoardCard = null;
+        _hoveredBoardDefinition = null;
+        _hoveredBoardSlot = null;
+        _draggedCard = null;
+        _draggedCardDefinition = null;
     }
 
     private bool TryParseSlotIndex(string name, out int index)
@@ -280,5 +610,8 @@ public class SlotRelationshipDisplay : MonoBehaviour
         public TMP_Text Label { get; }
         public bool LastActive { get; set; }
         public string LastText { get; set; }
+        public string RelationshipText { get; set; }
+        public bool HighlightFrom { get; set; }
+        public bool HighlightTo { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- raise drag start and end events from `CardDragHandler` so other systems can respond to active drags
- update the slot relationship display to track hovered board cards, the currently dragged card, and reset state when needed
- highlight connected slots and show relationship text when hovering related board cards while dragging, while keeping labels visible when slots already hold related cards

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68cf31ca7a308322aa20b8ae90318daa