### PR TITLE
Fix SlotRelationshipDisplay pointer enter braces

### DIFF
--- a/Assets/Scripts/SlotRelationshipDisplay.cs
+++ b/Assets/Scripts/SlotRelationshipDisplay.cs
@@ -311,7 +311,6 @@ public class SlotRelationshipDisplay : MonoBehaviour
             UpdateConnections();
             return;
         }
-    }
 
         if (_draggedCardDefinition == null)
         {


### PR DESCRIPTION
## Summary
- keep the board-slot hover logic inside `HandleCardPointerEnter` by removing the stray method terminator

## Testing
- not run (Unity project without automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cf3e0cbdcc8322b0ff1d8f466cc708