### PR TITLE
Fix regex escape sequences

### DIFF
--- a/Assets/Scripts/CardDataDefinitions.cs
+++ b/Assets/Scripts/CardDataDefinitions.cs
@@ -153,7 +153,7 @@ public class CharacterStats
 
 public static class CharacterStatsParser
 {
-    private static readonly Regex CharacterRegex = new Regex("\"(?<id>[^\"]+)\"\\s*:\\s*\{(?<body>[^}]*)\}", RegexOptions.Compiled | RegexOptions.Multiline);
+    private static readonly Regex CharacterRegex = new Regex("\"(?<id>[^\"]+)\"\\s*:\\s*\\{(?<body>[^}]*)\\}", RegexOptions.Compiled | RegexOptions.Multiline);
     private static readonly Regex FieldRegex = new Regex("\"(?<key>[^\"]+)\"\\s*:\\s*(?<value>-?\\d+)", RegexOptions.Compiled | RegexOptions.Multiline);
 
     public static Dictionary<string, CharacterStats> Parse(string json)


### PR DESCRIPTION
## Summary
- properly escape the literal braces in the character parsing regex to prevent compilation errors

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68cfc4000e9c8322a1103ce3cb64defb