### PR TITLE
Toggle card stats based on slot placement

### DIFF
--- a/Assets/Resources/Prefabs/Card.prefab
+++ b/Assets/Resources/Prefabs/Card.prefab
@@ -493,6 +493,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5735851196013634290}
   - component: {fileID: 3547998242888599151}
+  - component: {fileID: 3817404077664161191}
   m_Layer: 5
   m_Name: Card
   m_TagString: Untagged
@@ -530,10 +531,27 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d63796b76e7e422b97482d3afe76ff00, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   dragCanvas: {fileID: 0}
   returnToOriginalSlotIfRejected: 1
+--- !u!114 &3817404077664161191
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1244029720336922669}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1beb179a82b34c45bf32e5b36d702938, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  extraAttackRoot: {fileID: 6063957785860938069}
+  aoeRoot: {fileID: 4693165459085731199}
+  regenerationRoot: {fileID: 146044909934213915}
+  luckRoot: {fileID: 3079895993757005902}
+  scoreRoot: {fileID: 8890993833797184897}
 --- !u!1 &3079895993757005902
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CardStatVisibilityController.cs
+++ b/Assets/Scripts/CardStatVisibilityController.cs
@@ -1,0 +1,221 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class CardStatVisibilityController : MonoBehaviour
+{
+    [Header("Stat Roots")]
+    [SerializeField] private GameObject extraAttackRoot;
+    [SerializeField] private GameObject aoeRoot;
+    [SerializeField] private GameObject regenerationRoot;
+    [SerializeField] private GameObject luckRoot;
+    [SerializeField] private GameObject scoreRoot;
+
+    private readonly List<GameObject> _bonusStatRoots = new List<GameObject>(4);
+    private CardDragHandler _dragHandler;
+
+    private void Awake()
+    {
+        _dragHandler = GetComponent<CardDragHandler>();
+        EnsureReferences();
+        CacheBonusStatRoots();
+        UpdateVisibility();
+    }
+
+    private void OnEnable()
+    {
+        if (_dragHandler == null)
+        {
+            _dragHandler = GetComponent<CardDragHandler>();
+        }
+
+        EnsureReferences();
+        CacheBonusStatRoots();
+        UpdateVisibility();
+    }
+
+    private void OnTransformParentChanged()
+    {
+        if (_dragHandler != null && _dragHandler.IsDragging)
+        {
+            return;
+        }
+
+        UpdateVisibility();
+    }
+
+#if UNITY_EDITOR
+    private void OnValidate()
+    {
+        EnsureReferences();
+        CacheBonusStatRoots();
+        if (!Application.isPlaying)
+        {
+            return;
+        }
+
+        UpdateVisibility();
+    }
+#endif
+
+    private void EnsureReferences()
+    {
+        if (extraAttackRoot == null)
+        {
+            extraAttackRoot = FindChildGameObject("Canvas/Extra Attack");
+        }
+
+        if (aoeRoot == null)
+        {
+            aoeRoot = FindChildGameObject("Canvas/AOE");
+        }
+
+        if (regenerationRoot == null)
+        {
+            regenerationRoot = FindChildGameObject("Canvas/Regeneration");
+        }
+
+        if (luckRoot == null)
+        {
+            luckRoot = FindChildGameObject("Canvas/Luck");
+        }
+
+        if (scoreRoot == null)
+        {
+            scoreRoot = FindChildGameObject("Canvas/Score");
+        }
+    }
+
+    private GameObject FindChildGameObject(string path)
+    {
+        Transform child = transform.Find(path);
+        return child != null ? child.gameObject : null;
+    }
+
+    private void CacheBonusStatRoots()
+    {
+        _bonusStatRoots.Clear();
+        AddBonusRoot(extraAttackRoot);
+        AddBonusRoot(aoeRoot);
+        AddBonusRoot(regenerationRoot);
+        AddBonusRoot(luckRoot);
+    }
+
+    private void AddBonusRoot(GameObject root)
+    {
+        if (root == null || _bonusStatRoots.Contains(root))
+        {
+            return;
+        }
+
+        _bonusStatRoots.Add(root);
+    }
+
+    private void UpdateVisibility()
+    {
+        EnsureReferences();
+
+        CardSlot slot = GetActiveSlot();
+        CardContext context = DetermineContext(slot);
+        ApplyContext(context);
+    }
+
+    private CardSlot GetActiveSlot()
+    {
+        if (_dragHandler != null && _dragHandler.CurrentSlot != null)
+        {
+            return _dragHandler.CurrentSlot;
+        }
+
+        return GetComponentInParent<CardSlot>();
+    }
+
+    private CardContext DetermineContext(CardSlot slot)
+    {
+        if (slot != null && TryGetSlotIndex(slot.gameObject.name, out int slotIndex))
+        {
+            if (slotIndex >= 4 && slotIndex <= 6)
+            {
+                return CardContext.BackSlot;
+            }
+
+            if (slotIndex >= 1 && slotIndex <= 3)
+            {
+                return CardContext.FrontSlot;
+            }
+        }
+
+        if (GetComponentInParent<HandAreaHover>() != null)
+        {
+            return CardContext.Hand;
+        }
+
+        return CardContext.Other;
+    }
+
+    private bool TryGetSlotIndex(string slotName, out int slotIndex)
+    {
+        slotIndex = -1;
+        if (string.IsNullOrEmpty(slotName))
+        {
+            return false;
+        }
+
+        int startIndex = -1;
+        for (int i = 0; i < slotName.Length; i++)
+        {
+            if (char.IsDigit(slotName[i]))
+            {
+                startIndex = i;
+                break;
+            }
+        }
+
+        if (startIndex < 0)
+        {
+            return false;
+        }
+
+        int endIndex = startIndex;
+        while (endIndex < slotName.Length && char.IsDigit(slotName[endIndex]))
+        {
+            endIndex++;
+        }
+
+        string numberPart = slotName.Substring(startIndex, endIndex - startIndex);
+        return int.TryParse(numberPart, out slotIndex);
+    }
+
+    private void ApplyContext(CardContext context)
+    {
+        bool showBonusStats = context == CardContext.BackSlot;
+        bool showScore = context != CardContext.BackSlot;
+
+        SetBonusStatsActive(showBonusStats);
+        SetActive(scoreRoot, showScore);
+    }
+
+    private void SetBonusStatsActive(bool isActive)
+    {
+        for (int i = 0; i < _bonusStatRoots.Count; i++)
+        {
+            SetActive(_bonusStatRoots[i], isActive);
+        }
+    }
+
+    private void SetActive(GameObject target, bool isActive)
+    {
+        if (target != null && target.activeSelf != isActive)
+        {
+            target.SetActive(isActive);
+        }
+    }
+
+    private enum CardContext
+    {
+        Hand,
+        FrontSlot,
+        BackSlot,
+        Other
+    }
+}

--- a/Assets/Scripts/CardStatVisibilityController.cs.meta
+++ b/Assets/Scripts/CardStatVisibilityController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1beb179a82b34c45bf32e5b36d702938
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add a CardStatVisibilityController that toggles score and bonus stat objects depending on whether a card is in hand or specific slots
- attach the controller to the card prefab and hook up the Extra Attack, AOE, Regeneration, Luck, and Score objects

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68cfc755b7e0832284fe99615b98c408