### PR TITLE
Enable starting the game from the main menu

### DIFF
--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -893,6 +893,7 @@ GameObject:
   - component: {fileID: 1650169604}
   - component: {fileID: 1650169607}
   - component: {fileID: 1650169606}
+  - component: {fileID: 1650169608}
   - component: {fileID: 1650169605}
   m_Layer: 5
   m_Name: Button
@@ -964,7 +965,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1650169606}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1650169608}
+        m_TargetAssemblyTypeName: LoadSceneOnClick, Assembly-CSharp
+        m_MethodName: LoadScene
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument:
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1650169606
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -995,6 +1008,19 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1650169608
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1650169603}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e3c3d6f6c65d4a0cb97f314e02b26255, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  sceneName: Game
 --- !u!222 &1650169607
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/LoadSceneOnClick.cs
+++ b/Assets/Scripts/LoadSceneOnClick.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class LoadSceneOnClick : MonoBehaviour
+{
+    [SerializeField]
+    private string sceneName = "Game";
+
+    public void LoadScene()
+    {
+        if (!string.IsNullOrEmpty(sceneName))
+        {
+            SceneManager.LoadScene(sceneName);
+        }
+    }
+}

--- a/Assets/Scripts/LoadSceneOnClick.cs.meta
+++ b/Assets/Scripts/LoadSceneOnClick.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3c3d6f6c65d4a0cb97f314e02b26255
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add a reusable LoadSceneOnClick script that loads a configured scene
- hook the main menu play button to invoke the loader and open the Game scene

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cfcba761ac83228f501b781e2f77f2