### PR TITLE
Force hand cards to use requested stat visibility

### DIFF
--- a/Assets/Resources/Prefabs/Card.prefab
+++ b/Assets/Resources/Prefabs/Card.prefab
@@ -17,7 +17,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &7392439002531721905
 RectTransform:
   m_ObjectHideFlags: 0
@@ -569,7 +569,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &3664180847410270402
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1143,7 +1143,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &6501272631547536457
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1975,7 +1975,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &6832230254502430830
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2982,7 +2982,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1099695895292512365
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CardStatVisibilityController.cs
+++ b/Assets/Scripts/CardStatVisibilityController.cs
@@ -120,6 +120,12 @@ public class CardStatVisibilityController : MonoBehaviour
         ApplyContext(context);
     }
 
+    public void ForceHandDisplay()
+    {
+        EnsureReferences();
+        ApplyContext(CardContext.Hand);
+    }
+
     private CardSlot GetActiveSlot()
     {
         if (_dragHandler != null && _dragHandler.CurrentSlot != null)

--- a/Assets/Scripts/HandAreaHover.cs
+++ b/Assets/Scripts/HandAreaHover.cs
@@ -403,6 +403,7 @@ public class HandAreaHover : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
                 view = child.gameObject.AddComponent<CardView>();
             }
 
+            EnsureHandCardDisplay(view);
             _handCards.Add(view);
         }
 
@@ -433,6 +434,7 @@ public class HandAreaHover : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
                     view = cardObject.AddComponent<CardView>();
                 }
 
+                EnsureHandCardDisplay(view);
                 _handCards.Add(view);
             }
         }
@@ -500,6 +502,7 @@ public class HandAreaHover : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
 
             view.gameObject.SetActive(true);
             view.SetData(definition);
+            EnsureHandCardDisplay(view);
             UpdateCardTransform(view.RectTransform);
         }
 
@@ -709,6 +712,7 @@ public class HandAreaHover : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
 
         _activePreviewDefinition = sourceView.Definition;
         previewView.SetData(_activePreviewDefinition);
+        EnsureHandCardDisplay(previewView);
         ApplyPreviewTransform();
 
         if (_previewRectTransform != null && !_previewRectTransform.gameObject.activeSelf)
@@ -729,6 +733,48 @@ public class HandAreaHover : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
         if (_previewRectTransform != null)
         {
             _previewRectTransform.gameObject.SetActive(false);
+        }
+    }
+
+    private void EnsureHandCardDisplay(CardView view)
+    {
+        if (view == null)
+        {
+            return;
+        }
+
+        CardStatVisibilityController visibilityController = view.GetComponent<CardStatVisibilityController>();
+        if (visibilityController != null)
+        {
+            visibilityController.ForceHandDisplay();
+            return;
+        }
+
+        Transform viewTransform = view.transform;
+        SetChildActive(viewTransform, "Canvas/Extra Attack", false);
+        SetChildActive(viewTransform, "Canvas/AOE", false);
+        SetChildActive(viewTransform, "Canvas/Regeneration", false);
+        SetChildActive(viewTransform, "Canvas/Luck", false);
+        SetChildActive(viewTransform, "Canvas/Score", true);
+    }
+
+    private static void SetChildActive(Transform root, string childPath, bool isActive)
+    {
+        if (root == null || string.IsNullOrEmpty(childPath))
+        {
+            return;
+        }
+
+        Transform child = root.Find(childPath);
+        if (child == null)
+        {
+            return;
+        }
+
+        GameObject childObject = child.gameObject;
+        if (childObject.activeSelf != isActive)
+        {
+            childObject.SetActive(isActive);
         }
     }
 


### PR DESCRIPTION
## Summary
- add an API on `CardStatVisibilityController` to force the hand display state
- ensure cards created or activated in the hand area enforce the requested stat visibility regardless of prefab defaults
- update the hovered card preview to apply the same hand-only stat visibility configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfc9592a30832286cbe7e0469c1c38