### PR TITLE
Implement battle stat propagation between slots

### DIFF
--- a/Assets/Scripts/BattleResolver.cs
+++ b/Assets/Scripts/BattleResolver.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class BattleResolver : MonoBehaviour
+{
+    private static readonly Dictionary<string, CharacterStats.StatType> RelationStatMap = new Dictionary<string, CharacterStats.StatType>
+    {
+        { "baba", CharacterStats.StatType.Attack },
+        { "evlat", CharacterStats.StatType.Health },
+        { "kardes", CharacterStats.StatType.ExtraAttack },
+        { "anne", CharacterStats.StatType.Armor },
+        { "arkadas", CharacterStats.StatType.Luck },
+        { "es", CharacterStats.StatType.Regeneration },
+        { "akraba", CharacterStats.StatType.AreaDamage }
+    };
+
+    private readonly List<SlotBattleState> _slotStates = new List<SlotBattleState>();
+
+    public void ExecuteBattle()
+    {
+        BuildSlotStates();
+
+        if (_slotStates.Count == 0)
+        {
+            return;
+        }
+
+        for (int i = 0; i < _slotStates.Count; i++)
+        {
+            SlotBattleState source = _slotStates[i];
+            if (!source.HasCardData)
+            {
+                continue;
+            }
+
+            for (int j = i + 1; j < _slotStates.Count; j++)
+            {
+                SlotBattleState target = _slotStates[j];
+                if (!target.HasCardData)
+                {
+                    continue;
+                }
+
+                string relation = ResolveRelationship(source.Definition, target.Definition);
+                if (string.IsNullOrWhiteSpace(relation))
+                {
+                    continue;
+                }
+
+                if (!TryGetRelationStat(relation, out CharacterStats.StatType statType))
+                {
+                    continue;
+                }
+
+                int scoreValue = source.GetScoreValue();
+                if (scoreValue != 0)
+                {
+                    target.AddContribution(statType, scoreValue);
+                }
+
+                target.AbsorbContributions(source);
+            }
+        }
+
+        for (int i = 0; i < _slotStates.Count; i++)
+        {
+            _slotStates[i].ApplyFinalStats();
+        }
+    }
+
+    public void OnBattleButtonPressed()
+    {
+        ExecuteBattle();
+    }
+
+    private void BuildSlotStates()
+    {
+        _slotStates.Clear();
+
+        CardSlot[] slots = GetComponentsInChildren<CardSlot>(true);
+        if (slots == null || slots.Length == 0)
+        {
+            return;
+        }
+
+        for (int i = 0; i < slots.Length; i++)
+        {
+            CardSlot slot = slots[i];
+            if (slot == null)
+            {
+                continue;
+            }
+
+            if (!TryParseSlotIndex(slot.gameObject.name, out int slotIndex))
+            {
+                continue;
+            }
+
+            CardView view = GetActiveCardView(slot);
+            if (view == null)
+            {
+                continue;
+            }
+
+            var state = new SlotBattleState(slotIndex, slot, view);
+            state.Initialize();
+            if (state.HasCardData)
+            {
+                _slotStates.Add(state);
+            }
+        }
+
+        if (_slotStates.Count > 1)
+        {
+            _slotStates.Sort((a, b) => a.Index.CompareTo(b.Index));
+        }
+    }
+
+    private CardView GetActiveCardView(CardSlot slot)
+    {
+        if (slot == null)
+        {
+            return null;
+        }
+
+        Transform parent = slot.GetCardParent();
+        if (parent == null)
+        {
+            return null;
+        }
+
+        for (int i = 0; i < parent.childCount; i++)
+        {
+            Transform child = parent.GetChild(i);
+            if (child == null || !child.gameObject.activeInHierarchy)
+            {
+                continue;
+            }
+
+            CardDragHandler handler = child.GetComponent<CardDragHandler>();
+            if (handler == null || handler.CurrentSlot != slot)
+            {
+                continue;
+            }
+
+            CardView view = handler.GetComponent<CardView>();
+            if (view == null)
+            {
+                view = handler.GetComponentInChildren<CardView>(true);
+            }
+
+            if (view != null && view.gameObject.activeInHierarchy)
+            {
+                return view;
+            }
+        }
+
+        return null;
+    }
+
+    private string ResolveRelationship(CharacterCardDefinition from, CharacterCardDefinition to)
+    {
+        if (from == null || to == null)
+        {
+            return string.Empty;
+        }
+
+        string relation = GetDirectRelationship(from, to);
+        if (!string.IsNullOrWhiteSpace(relation))
+        {
+            return relation;
+        }
+
+        return GetDirectRelationship(to, from);
+    }
+
+    private string GetDirectRelationship(CharacterCardDefinition from, CharacterCardDefinition to)
+    {
+        if (from == null || to == null)
+        {
+            return string.Empty;
+        }
+
+        RelationshipInfo info = from.GetRelationshipById(to.id);
+        if (info != null && !string.IsNullOrWhiteSpace(info.relation))
+        {
+            return info.relation;
+        }
+
+        return string.Empty;
+    }
+
+    private bool TryGetRelationStat(string relation, out CharacterStats.StatType statType)
+    {
+        statType = default;
+        if (string.IsNullOrWhiteSpace(relation))
+        {
+            return false;
+        }
+
+        string key = NormalizeRelationshipKey(relation);
+        return RelationStatMap.TryGetValue(key, out statType);
+    }
+
+    private static string NormalizeRelationshipKey(string value)
+    {
+        string normalized = value.Trim().ToLowerInvariant();
+        normalized = normalized.Replace('ı', 'i')
+            .Replace('ş', 's')
+            .Replace('ğ', 'g')
+            .Replace('ü', 'u')
+            .Replace('ö', 'o')
+            .Replace('ç', 'c');
+        return normalized;
+    }
+
+    private bool TryParseSlotIndex(string slotName, out int index)
+    {
+        index = 0;
+        if (string.IsNullOrWhiteSpace(slotName))
+        {
+            return false;
+        }
+
+        const string prefix = "Slot ";
+        if (!slotName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        string suffix = slotName.Substring(prefix.Length).Trim();
+        return int.TryParse(suffix, out index);
+    }
+
+    private sealed class SlotBattleState
+    {
+        private readonly Dictionary<CharacterStats.StatType, int> _contributions = new Dictionary<CharacterStats.StatType, int>();
+
+        public SlotBattleState(int index, CardSlot slot, CardView view)
+        {
+            Index = index;
+            Slot = slot;
+            View = view;
+        }
+
+        public int Index { get; }
+        public CardSlot Slot { get; }
+        public CardView View { get; }
+        public CharacterCardDefinition Definition { get; private set; }
+        public CharacterStats BaseStats { get; private set; }
+        public CharacterStats FinalStats { get; private set; }
+
+        public bool HasCardData => View != null && Definition != null;
+
+        public void Initialize()
+        {
+            _contributions.Clear();
+
+            if (View == null)
+            {
+                Definition = null;
+                BaseStats = null;
+                FinalStats = null;
+                return;
+            }
+
+            Definition = View.Definition;
+            View.ResetToBaseStats();
+            BaseStats = View.GetBaseStatsClone();
+            FinalStats = BaseStats != null ? new CharacterStats(BaseStats) : new CharacterStats();
+        }
+
+        public int GetScoreValue()
+        {
+            return BaseStats != null ? BaseStats.score : 0;
+        }
+
+        public void AddContribution(CharacterStats.StatType statType, int amount)
+        {
+            if (amount == 0)
+            {
+                return;
+            }
+
+            if (_contributions.TryGetValue(statType, out int existing))
+            {
+                _contributions[statType] = existing + amount;
+            }
+            else
+            {
+                _contributions[statType] = amount;
+            }
+
+            if (FinalStats == null)
+            {
+                FinalStats = new CharacterStats();
+            }
+
+            FinalStats.AddToStat(statType, amount);
+        }
+
+        public void AbsorbContributions(SlotBattleState source)
+        {
+            if (source == null || source._contributions.Count == 0)
+            {
+                return;
+            }
+
+            foreach (KeyValuePair<CharacterStats.StatType, int> pair in source._contributions)
+            {
+                AddContribution(pair.Key, pair.Value);
+            }
+        }
+
+        public void ApplyFinalStats()
+        {
+            if (View == null)
+            {
+                return;
+            }
+
+            View.ApplyStats(FinalStats);
+        }
+    }
+}
+

--- a/Assets/Scripts/BattleResolver.cs.meta
+++ b/Assets/Scripts/BattleResolver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 446e8853b54a48978f91248c4b92c9ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/CardDataDefinitions.cs
+++ b/Assets/Scripts/CardDataDefinitions.cs
@@ -63,6 +63,18 @@ public class CharacterRelationshipDatabase
 [Serializable]
 public class CharacterStats
 {
+    public enum StatType
+    {
+        Attack,
+        Health,
+        Armor,
+        ExtraAttack,
+        AreaDamage,
+        Regeneration,
+        Luck,
+        Score
+    }
+
     public int attack;
     public int health;
     public int armor;
@@ -96,6 +108,77 @@ public class CharacterStats
         luck = other.luck;
         score = other.score;
         _hasValues = other._hasValues;
+    }
+
+    public int GetValue(StatType statType)
+    {
+        switch (statType)
+        {
+            case StatType.Attack:
+                return attack;
+            case StatType.Health:
+                return health;
+            case StatType.Armor:
+                return armor;
+            case StatType.ExtraAttack:
+                return extraAttack;
+            case StatType.AreaDamage:
+                return areaDamage;
+            case StatType.Regeneration:
+                return regeneration;
+            case StatType.Luck:
+                return luck;
+            case StatType.Score:
+                return score;
+            default:
+                return 0;
+        }
+    }
+
+    public void SetValue(StatType statType, int value)
+    {
+        switch (statType)
+        {
+            case StatType.Attack:
+                attack = value;
+                break;
+            case StatType.Health:
+                health = value;
+                break;
+            case StatType.Armor:
+                armor = value;
+                break;
+            case StatType.ExtraAttack:
+                extraAttack = value;
+                break;
+            case StatType.AreaDamage:
+                areaDamage = value;
+                break;
+            case StatType.Regeneration:
+                regeneration = value;
+                break;
+            case StatType.Luck:
+                luck = value;
+                break;
+            case StatType.Score:
+                score = value;
+                break;
+            default:
+                return;
+        }
+
+        _hasValues = true;
+    }
+
+    public void AddToStat(StatType statType, int amount)
+    {
+        if (amount == 0)
+        {
+            return;
+        }
+
+        int newValue = GetValue(statType) + amount;
+        SetValue(statType, newValue);
     }
 
     public void AssignValue(string key, int value)

--- a/Assets/Scripts/CardView.cs
+++ b/Assets/Scripts/CardView.cs
@@ -22,6 +22,8 @@ public class CardView : MonoBehaviour
 
     private RectTransform _rectTransform;
     private CharacterCardDefinition _definition;
+    private CharacterStats _baseStats;
+    private bool _baseStatsCached;
 
     public CharacterCardDefinition Definition => _definition;
 
@@ -43,6 +45,7 @@ public class CardView : MonoBehaviour
         _rectTransform = GetComponent<RectTransform>();
         EnsureTextReferences();
         EnsureImageReference();
+        CacheBaseStats();
         if (_definition != null)
         {
             ApplyDefinition();
@@ -60,6 +63,8 @@ public class CardView : MonoBehaviour
         _rectTransform = GetComponent<RectTransform>();
         EnsureTextReferences();
         EnsureImageReference();
+        _baseStats = null;
+        _baseStatsCached = false;
         UpdatePortraitSprite();
         UpdateStatsText();
     }
@@ -87,6 +92,9 @@ public class CardView : MonoBehaviour
     public void SetData(CharacterCardDefinition definition)
     {
         _definition = definition;
+        _baseStats = null;
+        _baseStatsCached = false;
+        CacheBaseStats();
         ApplyDefinition();
 
         if (_definition != null && !string.IsNullOrEmpty(_definition.id))
@@ -99,6 +107,7 @@ public class CardView : MonoBehaviour
     {
         EnsureTextReferences();
         EnsureImageReference();
+        CacheBaseStats();
 
         if (nameText != null)
         {
@@ -423,6 +432,88 @@ public class CardView : MonoBehaviour
         }
 
         return target.GetComponentInChildren<Image>(true);
+    }
+
+    private void CacheBaseStats()
+    {
+        if (_baseStatsCached)
+        {
+            return;
+        }
+
+        if (_definition != null && _definition.stats != null)
+        {
+            _baseStats = new CharacterStats(_definition.stats);
+            _baseStatsCached = true;
+        }
+    }
+
+    public CharacterStats GetBaseStatsClone()
+    {
+        if (!_baseStatsCached)
+        {
+            CacheBaseStats();
+        }
+
+        return _baseStats != null ? new CharacterStats(_baseStats) : null;
+    }
+
+    public void ResetToBaseStats()
+    {
+        if (_definition == null)
+        {
+            return;
+        }
+
+        if (!_baseStatsCached)
+        {
+            CacheBaseStats();
+        }
+
+        if (_baseStats != null)
+        {
+            _definition.stats = new CharacterStats(_baseStats);
+        }
+        else if (_definition.stats != null)
+        {
+            _definition.stats = new CharacterStats(_definition.stats);
+        }
+
+        UpdateStatsText();
+    }
+
+    public void ApplyStats(CharacterStats stats, bool updateBase = false)
+    {
+        if (_definition == null)
+        {
+            return;
+        }
+
+        if (stats != null)
+        {
+            _definition.stats = new CharacterStats(stats);
+            if (updateBase)
+            {
+                _baseStats = new CharacterStats(stats);
+                _baseStatsCached = true;
+            }
+        }
+        else
+        {
+            _definition.stats = null;
+            if (updateBase)
+            {
+                _baseStats = null;
+                _baseStatsCached = true;
+            }
+        }
+
+        UpdateStatsText();
+    }
+
+    public void RefreshStatsDisplay()
+    {
+        UpdateStatsText();
     }
 
     private string GetDebugContext()


### PR DESCRIPTION
## Summary
- add a battle resolver that propagates relationship-driven bonuses from lower-index slots to higher ones
- extend card views to cache base stats and apply computed battle results
- add helper APIs on character stats to support stat-specific updates

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68cfd5af9e388322ae8f4986ebc75a46