### PR TITLE
Populate monster prefab from monsters.json

### DIFF
--- a/Assets/Resources/Prefabs/Monster.prefab
+++ b/Assets/Resources/Prefabs/Monster.prefab
@@ -608,6 +608,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5291616826415902347}
+  - component: {fileID: 3307130535967812345}
   m_Layer: 0
   m_Name: Monster
   m_TagString: Untagged
@@ -631,3 +632,21 @@ Transform:
   - {fileID: 1124739590713166972}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3307130535967812345
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7290527602225548259}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89faa1764ec5412ebab16009342f30b4, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  monsterId: Monster_01
+  monstersResourcePath: Data/monsters
+  spriteResourceFolder:
+  portraitImage: {fileID: 7708072685995986667}
+  healthValueText: {fileID: 6546815937503847460}
+  attackValueText: {fileID: 2166686395519082865}

--- a/Assets/Scripts/MonsterView.cs
+++ b/Assets/Scripts/MonsterView.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+[ExecuteAlways]
+[DisallowMultipleComponent]
+public class MonsterView : MonoBehaviour
+{
+    [SerializeField] private string monsterId = "Monster_01";
+    [SerializeField] private string monstersResourcePath = "Data/monsters";
+    [SerializeField] private string spriteResourceFolder = string.Empty;
+    [SerializeField] private Image portraitImage;
+    [SerializeField] private TMP_Text healthValueText;
+    [SerializeField] private TMP_Text attackValueText;
+
+    private static readonly Dictionary<string, Dictionary<string, MonsterStats>> Cache = new Dictionary<string, Dictionary<string, MonsterStats>>(StringComparer.OrdinalIgnoreCase);
+
+    private void Awake()
+    {
+        EnsureReferences();
+        ApplyMonsterData();
+    }
+
+    private void Reset()
+    {
+        EnsureReferences();
+        ApplyMonsterData();
+    }
+
+    private void OnValidate()
+    {
+        if (!Application.isPlaying)
+        {
+            EnsureReferences();
+            ApplyMonsterData();
+        }
+    }
+
+    private void EnsureReferences()
+    {
+        if (portraitImage == null)
+        {
+            Transform imageTransform = transform.Find("Canvas/Image");
+            if (imageTransform != null)
+            {
+                portraitImage = imageTransform.GetComponent<Image>();
+            }
+        }
+
+        if (attackValueText == null)
+        {
+            Transform attackTextTransform = transform.Find("Canvas/Attack/Text (TMP)");
+            if (attackTextTransform != null)
+            {
+                attackValueText = attackTextTransform.GetComponent<TMP_Text>();
+            }
+        }
+
+        if (healthValueText == null)
+        {
+            Transform healthTextTransform = transform.Find("Canvas/Health/Text (TMP)");
+            if (healthTextTransform != null)
+            {
+                healthValueText = healthTextTransform.GetComponent<TMP_Text>();
+            }
+        }
+    }
+
+    private void ApplyMonsterData()
+    {
+        if (string.IsNullOrWhiteSpace(monsterId))
+        {
+            SetText(attackValueText, string.Empty);
+            SetText(healthValueText, string.Empty);
+            return;
+        }
+
+        MonsterStats stats = GetMonsterStats(monsterId);
+        if (stats == null)
+        {
+            SetText(attackValueText, string.Empty);
+            SetText(healthValueText, string.Empty);
+            return;
+        }
+
+        SetText(attackValueText, stats.attackAssigned ? stats.attack.ToString() : string.Empty);
+        SetText(healthValueText, stats.healthAssigned ? stats.health.ToString() : string.Empty);
+
+        UpdatePortrait(monsterId);
+        gameObject.name = monsterId;
+    }
+
+    private void UpdatePortrait(string id)
+    {
+        if (portraitImage == null || string.IsNullOrWhiteSpace(id))
+        {
+            return;
+        }
+
+        string resourcePath = BuildSpriteResourcePath(id);
+        Sprite sprite = Resources.Load<Sprite>(resourcePath);
+        if (sprite == null && !string.Equals(resourcePath, id, StringComparison.Ordinal))
+        {
+            sprite = Resources.Load<Sprite>(id);
+        }
+
+        if (sprite != null)
+        {
+            portraitImage.sprite = sprite;
+        }
+        else
+        {
+            Debug.LogWarning($"Sprite for monster '{id}' could not be found at Resources/{resourcePath}.");
+        }
+    }
+
+    private string BuildSpriteResourcePath(string id)
+    {
+        if (string.IsNullOrWhiteSpace(spriteResourceFolder))
+        {
+            return id;
+        }
+
+        if (spriteResourceFolder.EndsWith("/", StringComparison.Ordinal))
+        {
+            return spriteResourceFolder + id;
+        }
+
+        return spriteResourceFolder + "/" + id;
+    }
+
+    private static void SetText(TMP_Text textComponent, string value)
+    {
+        if (textComponent != null)
+        {
+            textComponent.text = value ?? string.Empty;
+        }
+    }
+
+    private MonsterStats GetMonsterStats(string id)
+    {
+        if (string.IsNullOrWhiteSpace(monstersResourcePath))
+        {
+            Debug.LogWarning("Monsters resource path is empty.");
+            return null;
+        }
+
+        if (!Cache.TryGetValue(monstersResourcePath, out Dictionary<string, MonsterStats> lookup) || lookup == null)
+        {
+            lookup = LoadMonsterStats(monstersResourcePath);
+            Cache[monstersResourcePath] = lookup;
+        }
+
+        if (lookup != null && lookup.TryGetValue(id, out MonsterStats stats))
+        {
+            return stats;
+        }
+
+        Debug.LogWarning($"Monster stats for '{id}' could not be found in {monstersResourcePath}.");
+        return null;
+    }
+
+    private static Dictionary<string, MonsterStats> LoadMonsterStats(string resourcePath)
+    {
+        var result = new Dictionary<string, MonsterStats>(StringComparer.OrdinalIgnoreCase);
+
+        TextAsset monstersAsset = Resources.Load<TextAsset>(resourcePath);
+        if (monstersAsset == null)
+        {
+            Debug.LogWarning($"Monster data could not be loaded from Resources/{resourcePath}.");
+            return result;
+        }
+
+        foreach (Match monsterMatch in MonsterRegex.Matches(monstersAsset.text))
+        {
+            if (!monsterMatch.Success)
+            {
+                continue;
+            }
+
+            string id = monsterMatch.Groups["id"].Value;
+            string body = monsterMatch.Groups["body"].Value;
+
+            if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(body))
+            {
+                continue;
+            }
+
+            MonsterStats stats = ParseMonsterStats(body);
+            if (stats != null && stats.HasValues)
+            {
+                result[id] = stats;
+            }
+        }
+
+        return result;
+    }
+
+    private static MonsterStats ParseMonsterStats(string body)
+    {
+        if (string.IsNullOrEmpty(body))
+        {
+            return null;
+        }
+
+        var stats = new MonsterStats();
+
+        foreach (Match fieldMatch in FieldRegex.Matches(body))
+        {
+            if (!fieldMatch.Success)
+            {
+                continue;
+            }
+
+            string key = fieldMatch.Groups["key"].Value;
+            string valueText = fieldMatch.Groups["value"].Value;
+
+            if (!int.TryParse(valueText, out int value))
+            {
+                continue;
+            }
+
+            stats.AssignValue(key, value);
+        }
+
+        return stats;
+    }
+
+    [Serializable]
+    private class MonsterStats
+    {
+        public int attack;
+        public int health;
+        public int value;
+
+        public bool attackAssigned;
+        public bool healthAssigned;
+        public bool valueAssigned;
+
+        public bool HasValues => attackAssigned || healthAssigned || valueAssigned;
+
+        public void AssignValue(string key, int amount)
+        {
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                return;
+            }
+
+            string normalized = NormalizeKey(key);
+            switch (normalized)
+            {
+                case "can":
+                case "health":
+                case "hp":
+                    health = amount;
+                    healthAssigned = true;
+                    break;
+                case "saldiri":
+                case "atak":
+                case "hasar":
+                case "attack":
+                case "damage":
+                    attack = amount;
+                    attackAssigned = true;
+                    break;
+                case "deger":
+                case "value":
+                    value = amount;
+                    valueAssigned = true;
+                    break;
+            }
+        }
+    }
+
+    private static string NormalizeKey(string value)
+    {
+        string normalized = value.Trim().ToLowerInvariant();
+        normalized = normalized.Replace('ı', 'i');
+        normalized = normalized.Replace('ğ', 'g');
+        normalized = normalized.Replace('ş', 's');
+        normalized = normalized.Replace('ç', 'c');
+        normalized = normalized.Replace('ö', 'o');
+        normalized = normalized.Replace('ü', 'u');
+        return normalized;
+    }
+
+    private static readonly Regex MonsterRegex = new Regex("\"(?<id>[^\"]+)\"\\s*:\\s*\\{(?<body>[^}]*)\\}", RegexOptions.Compiled | RegexOptions.Multiline);
+    private static readonly Regex FieldRegex = new Regex("\"(?<key>[^\"]+)\"\\s*:\\s*(?<value>-?\\d+)", RegexOptions.Compiled | RegexOptions.Multiline);
+}

--- a/Assets/Scripts/MonsterView.cs.meta
+++ b/Assets/Scripts/MonsterView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 89faa1764ec5412ebab16009342f30b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add a MonsterView behaviour that loads monster data from Resources/Data/monsters.json, caches it, and updates the prefab visuals
- attach the new behaviour to the Monster prefab and wire the portrait plus attack/health text fields

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cfd8e217d4832285bb5a20cb6797ab