### PR TITLE
Update relationship stat mappings

### DIFF
--- a/Assets/Scripts/BattleResolver.cs
+++ b/Assets/Scripts/BattleResolver.cs
@@ -11,11 +11,11 @@ public class BattleResolver : MonoBehaviour
     {
         { "baba", CharacterStats.StatType.Attack },
         { "evlat", CharacterStats.StatType.Health },
-        { "kardes", CharacterStats.StatType.ExtraAttack },
+        { "kardes", CharacterStats.StatType.AreaDamage },
         { "anne", CharacterStats.StatType.Armor },
         { "arkadas", CharacterStats.StatType.Luck },
         { "es", CharacterStats.StatType.Regeneration },
-        { "akraba", CharacterStats.StatType.AreaDamage }
+        { "akraba", CharacterStats.StatType.Health }
     };
 
     [SerializeField] private bool enableDebugLogging = true;


### PR DESCRIPTION
## Summary
- swap the relationship contributions for sibling and relative bonds
- relatives now boost health while siblings provide area damage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d002d1eeec832296d9ff229db5d094