### PR TITLE
Add monster wave controller for random wave spawns

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -1633,6 +1633,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2100000001}
   - component: {fileID: 2100000002}
+  - component: {fileID: 2100000003}
   m_Layer: 0
   m_Name: BattleResolver
   m_TagString: Untagged
@@ -1677,6 +1678,26 @@ MonoBehaviour:
   delayBeforeThirdCameraMove: 2
   thirdCameraPosition: {fileID: 614864199}
   thirdCameraMoveSpeed: 10
+--- !u!114 &2100000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d4aa2dfb10bd4834a5f24f195ef5aad5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  availableMonsterIds:
+  - Monster_01
+  - Monster_02
+  - Monster_03
+  - Monster_04
+  - Monster_05
+  initialWaveSize: 1
+  includeInactiveMonsters: 1
 --- !u!1001 &2729780815738096287
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/MonsterView.cs
+++ b/Assets/Scripts/MonsterView.cs
@@ -18,6 +18,34 @@ public class MonsterView : MonoBehaviour
 
     private static readonly Dictionary<string, Dictionary<string, MonsterStats>> Cache = new Dictionary<string, Dictionary<string, MonsterStats>>(StringComparer.OrdinalIgnoreCase);
 
+    public string MonsterId => monsterId;
+
+    public void SetMonsterId(string id, bool applyImmediately = true)
+    {
+        string normalizedId = id ?? string.Empty;
+        if (string.Equals(monsterId, normalizedId, StringComparison.Ordinal))
+        {
+            if (applyImmediately)
+            {
+                ApplyMonsterData();
+            }
+
+            return;
+        }
+
+        monsterId = normalizedId;
+
+        if (applyImmediately)
+        {
+            ApplyMonsterData();
+        }
+    }
+
+    public void RefreshView()
+    {
+        ApplyMonsterData();
+    }
+
     private void Awake()
     {
         EnsureReferences();

--- a/Assets/Scripts/MonsterWaveController.cs
+++ b/Assets/Scripts/MonsterWaveController.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class MonsterWaveController : MonoBehaviour
+{
+    [SerializeField] private List<string> availableMonsterIds = new List<string>
+    {
+        "Monster_01",
+        "Monster_02",
+        "Monster_03",
+        "Monster_04",
+        "Monster_05"
+    };
+
+    [SerializeField] [Min(0)] private int initialWaveSize = 1;
+    [SerializeField] private bool includeInactiveMonsters = true;
+
+    private readonly List<MonsterView> _monsterSlots = new List<MonsterView>();
+    private bool _initialWaveSpawned;
+    private int _currentWaveSize;
+    private int _currentWaveNumber;
+
+    public IReadOnlyList<MonsterView> MonsterSlots => _monsterSlots;
+    public int CurrentWaveSize => _currentWaveSize;
+    public int CurrentWaveNumber => _currentWaveNumber;
+
+    private void Awake()
+    {
+        CollectMonsterSlots();
+        _currentWaveSize = Mathf.Clamp(initialWaveSize, 0, _monsterSlots.Count);
+    }
+
+    private void Start()
+    {
+        EnsureInitialWave();
+    }
+
+    public void EnsureInitialWave()
+    {
+        if (_initialWaveSpawned)
+        {
+            return;
+        }
+
+        if (_monsterSlots.Count == 0)
+        {
+            Debug.LogWarning("[MonsterWaveController] No MonsterView components were found to populate the initial wave.");
+            return;
+        }
+
+        _currentWaveNumber = _currentWaveSize > 0 ? 1 : 0;
+        SpawnWave(_currentWaveSize);
+        _initialWaveSpawned = true;
+    }
+
+    [ContextMenu("Advance To Next Wave")]
+    public void AdvanceToNextWave()
+    {
+        if (!_initialWaveSpawned)
+        {
+            EnsureInitialWave();
+            return;
+        }
+
+        if (_monsterSlots.Count == 0)
+        {
+            Debug.LogWarning("[MonsterWaveController] Cannot advance waves because no MonsterView components are available.");
+            return;
+        }
+
+        int desiredSize = Mathf.Clamp(_currentWaveSize + 1, 0, _monsterSlots.Count);
+        if (desiredSize == 0)
+        {
+            desiredSize = Mathf.Min(1, _monsterSlots.Count);
+        }
+
+        if (desiredSize == _currentWaveSize)
+        {
+            SpawnWave(_currentWaveSize);
+            _currentWaveNumber++;
+            return;
+        }
+
+        _currentWaveSize = desiredSize;
+        _currentWaveNumber++;
+        SpawnWave(_currentWaveSize);
+    }
+
+    public void ResetWaves()
+    {
+        _currentWaveSize = Mathf.Clamp(initialWaveSize, 0, _monsterSlots.Count);
+        _currentWaveNumber = 0;
+        _initialWaveSpawned = false;
+        EnsureInitialWave();
+    }
+
+    private void CollectMonsterSlots()
+    {
+        _monsterSlots.Clear();
+
+        MonsterView[] foundMonsters = FindObjectsOfType<MonsterView>(includeInactiveMonsters);
+        foreach (MonsterView monster in foundMonsters)
+        {
+            if (monster == null)
+            {
+                continue;
+            }
+
+            if (!monster.gameObject.scene.IsValid() || monster.gameObject.scene != gameObject.scene)
+            {
+                continue;
+            }
+
+            _monsterSlots.Add(monster);
+        }
+
+        if (_monsterSlots.Count == 0)
+        {
+            Debug.LogWarning("[MonsterWaveController] CollectMonsterSlots found no MonsterView instances in the active scene.");
+        }
+    }
+
+    private void SpawnWave(int desiredActiveCount)
+    {
+        if (availableMonsterIds == null || availableMonsterIds.Count == 0)
+        {
+            Debug.LogWarning("[MonsterWaveController] No monster identifiers configured for spawning.");
+            return;
+        }
+
+        if (_monsterSlots.Count == 0)
+        {
+            Debug.LogWarning("[MonsterWaveController] SpawnWave called with no MonsterView slots available.");
+            return;
+        }
+
+        int clampedCount = Mathf.Clamp(desiredActiveCount, 0, _monsterSlots.Count);
+        ShuffleMonsterSlots();
+
+        for (int i = 0; i < _monsterSlots.Count; i++)
+        {
+            MonsterView slot = _monsterSlots[i];
+            if (slot == null)
+            {
+                continue;
+            }
+
+            bool shouldBeActive = i < clampedCount;
+            GameObject slotObject = slot.gameObject;
+            if (slotObject.activeSelf != shouldBeActive)
+            {
+                slotObject.SetActive(shouldBeActive);
+            }
+
+            if (shouldBeActive)
+            {
+                string monsterId = SelectRandomMonsterId();
+                slot.SetMonsterId(monsterId);
+            }
+        }
+    }
+
+    private string SelectRandomMonsterId()
+    {
+        int index = UnityEngine.Random.Range(0, availableMonsterIds.Count);
+        return availableMonsterIds[index];
+    }
+
+    private void ShuffleMonsterSlots()
+    {
+        for (int i = _monsterSlots.Count - 1; i > 0; i--)
+        {
+            int swapIndex = UnityEngine.Random.Range(0, i + 1);
+            MonsterView temp = _monsterSlots[i];
+            _monsterSlots[i] = _monsterSlots[swapIndex];
+            _monsterSlots[swapIndex] = temp;
+        }
+    }
+}

--- a/Assets/Scripts/MonsterWaveController.cs.meta
+++ b/Assets/Scripts/MonsterWaveController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4aa2dfb10bd4834a5f24f195ef5aad5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add a MonsterWaveController that randomises Monster_05 instances and grows the active count for each wave
- expose setters on MonsterView so the controller can swap monster ids at runtime
- register the new wave controller on the Game scene

## Testing
- not run (Unity test framework not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d0063de7e883229749873d32e53556