### PR TITLE
Add MonsterWar helper for combat coroutine

### DIFF
--- a/Assets/Scripts/BattleResolver.cs
+++ b/Assets/Scripts/BattleResolver.cs
@@ -151,8 +151,13 @@ public class BattleResolver : MonoBehaviour
             yield return new WaitForSeconds(combatStartDelay);
         }
 
-        yield return RunCombatLoop();
+        yield return MonsterWar.SelfMonsterWar(this);
         _combatRoutine = null;
+    }
+
+    internal IEnumerator RunSelfMonsterWar()
+    {
+        return RunCombatLoop();
     }
 
     private IEnumerator RunCombatLoop()

--- a/Assets/Scripts/MonsterWar.cs
+++ b/Assets/Scripts/MonsterWar.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using UnityEngine;
+
+public static class MonsterWar
+{
+    private const string LogPrefix = "[MonsterWar]";
+
+    public static IEnumerator SelfMonsterWar(BattleResolver resolver)
+    {
+        if (resolver == null)
+        {
+            Debug.LogWarning($"{LogPrefix} BattleResolver reference was null when attempting to run a monster war.");
+            yield break;
+        }
+
+        IEnumerator routine = resolver.RunSelfMonsterWar();
+        if (routine == null)
+        {
+            Debug.LogWarning($"{LogPrefix} BattleResolver did not provide a combat routine.");
+            yield break;
+        }
+
+        yield return routine;
+    }
+}

--- a/Assets/Scripts/MonsterWar.cs.meta
+++ b/Assets/Scripts/MonsterWar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7abd729d787640f0a7f487a04dadd4d3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add a `MonsterWar` helper script that exposes the static `SelfMonsterWar` coroutine wrapper
- expose a wrapper on `BattleResolver` so combat countdown defers to the helper method

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d00e1b2538832296c5e68072dbaf61