### PR TITLE
Remove redundant method conflicting with class name

### DIFF
--- a/Assets/Scripts/LoadSceneOnClick.cs
+++ b/Assets/Scripts/LoadSceneOnClick.cs
@@ -13,6 +13,4 @@ public class LoadSceneOnClick : MonoBehaviour
             SceneManager.LoadScene(sceneName);
         }
     }
-
-    public void LoadSceneOnClick() => LoadScene();
 }


### PR DESCRIPTION
## Summary
- remove the extra LoadSceneOnClick method that conflicted with the MonoBehaviour name

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d010af5e588322bd7959ccfc0880b0