### PR TITLE
Add flag for third camera focus

### DIFF
--- a/Assets/Scripts/BattleResolver.cs
+++ b/Assets/Scripts/BattleResolver.cs
@@ -41,6 +41,7 @@ public class BattleResolver : MonoBehaviour
 
     private Coroutine _cameraSequenceRoutine;
     private Coroutine _combatRoutine;
+    private bool _hasAppliedThirdCameraFocus;
 
     private const string LogPrefix = "[BattleResolver]";
     private const int FocusSlotMinimumIndex = 4;


### PR DESCRIPTION
## Summary
- declare a private boolean flag on BattleResolver to track whether the third camera focus has been applied

## Testing
- Not run (Unity editor not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d015776ad883229c7b58d95af37174